### PR TITLE
Fixes #5 Empty field outputs <p>&nbsp;</p>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 
 ### Fixed
 - Fixed a deprecation error when running Redactor on Craft 3.0.0-RC15 or later.
+- Fixed a bug where an empty CKEditor field would return some HTML content.
 
 ## 1.0.0-beta.2 - 2018-01-15
 

--- a/src/Field.php
+++ b/src/Field.php
@@ -80,6 +80,7 @@ class Field extends \craft\base\Field
             return $value;
         }
 
+        // TODO: See if this is still necessary after updating to latest CKEditor.
         if ($value === '<p>&nbsp;</p>') {
             return null;
         }

--- a/src/Field.php
+++ b/src/Field.php
@@ -80,6 +80,11 @@ class Field extends \craft\base\Field
             return $value;
         }
 
+        if ($value === '<p>&nbsp;</p>') {
+            $value = null;
+            return $value;
+        }
+
         // Prevent everyone from having to use the |raw filter when outputting RTE content
         return Template::raw($value);
     }

--- a/src/Field.php
+++ b/src/Field.php
@@ -81,8 +81,7 @@ class Field extends \craft\base\Field
         }
 
         if ($value === '<p>&nbsp;</p>') {
-            $value = null;
-            return $value;
+            return null;
         }
 
         // Prevent everyone from having to use the |raw filter when outputting RTE content


### PR DESCRIPTION
If the CKEditor field is left empty, replace the empty <p> tags with a value of null.