### PR TITLE
[bugfix] add second argument to isValueEmpty call

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -124,7 +124,7 @@ class Field extends \craft\base\Field
     public function isValueEmpty($value, ElementInterface $element): bool
     {
         /** @var \Twig_Markup|null $value */
-        return $value === null || parent::isValueEmpty((string)$value);
+        return $value === null || parent::isValueEmpty((string)$value, $element);
     }
 
     /**


### PR DESCRIPTION
causes an "invalid argument" 500 error when saving entry with a ckeditor field