### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cd /path/to/my-project.test
 composer require craftcms/ckeditor
 
 # tell Craft to install the plugin
-./craft install/plugin ckeditor
+./craft plugin/install ckeditor
 ```
 
 ## Providing a CKEditor Build


### PR DESCRIPTION
Change the install options to get rid of 

```
                                                 
    The install/plugin command is deprecated.    
        Running plugin/install instead...        

```

error

### Description



### Related issues

