### PR TITLE
fix for no source volumes being returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Added RTL language support. ([#33](https://github.com/craftcms/ckeditor/issues/33), [#55](https://github.com/craftcms/ckeditor/pull/55))
+- Fixed a bug where it wasn’t possible to browse files. ([#45](https://github.com/craftcms/ckeditor/issues/45))
 
 ## 2.0.0 - 2022-05-03
 

--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -5,7 +5,6 @@ namespace craft\ckeditor\controllers;
 use Craft;
 use craft\ckeditor\Field;
 use craft\elements\Asset;
-use craft\helpers\Db;
 use craft\web\Controller;
 use craft\web\View;
 use yii\base\ExitException;

--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -144,39 +144,15 @@ JS;
             throw new BadRequestHttpException('The CKEditor field does not have access to any volumes.');
         }
 
-        $criteria = ['parentId' => ':empty:'];
-
         $allVolumes = Craft::$app->getVolumes()->getAllVolumes();
-        $allowedVolumes = [];
         $userService = Craft::$app->getUser();
+        $sources = [];
 
         foreach ($allVolumes as $volume) {
             $allowedBySettings = $field->availableVolumes === '*' || (is_array($field->availableVolumes) && in_array($volume->uid, $field->availableVolumes));
-            if ($allowedBySettings && ($field->showUnpermittedVolumes || $userService->checkPermission("viewVolume:$volume->uid"))) {
-                $allowedVolumes[] = $volume->uid;
+            if ($allowedBySettings && ($field->showUnpermittedVolumes || $userService->checkPermission("viewAssets:$volume->uid"))) {
+                $sources[] = "volume:$volume->uid";
             }
-        }
-
-        $criteria['volumeId'] = Db::idsByUids('{{%volumes}}', $allowedVolumes);
-
-        $folders = Craft::$app->getAssets()->findFolders($criteria);
-
-        // Sort volumes in the same order as they are sorted in the CP
-        $sortedVolumeIds = Craft::$app->getVolumes()->getAllVolumeIds();
-        $sortedVolumeIds = array_flip($sortedVolumeIds);
-
-        $sources = [];
-
-        usort($folders, function($a, $b) use ($sortedVolumeIds) {
-            // In case Temporary volumes ever make an appearance in RTF modals, sort them to the end of the list.
-            $aOrder = $sortedVolumeIds[$a->volumeId] ?? PHP_INT_MAX;
-            $bOrder = $sortedVolumeIds[$b->volumeId] ?? PHP_INT_MAX;
-
-            return $aOrder - $bOrder;
-        });
-
-        foreach ($folders as $folder) {
-            $sources[] = "folder:$folder->uid";
         }
 
         return $sources;


### PR DESCRIPTION
### Description
When using CKEditor4, no sources were being returned via `src/controllers/AssetsController.php->_sources()`. The code relied on the Craft 3 approach of checking for `folder:$uid` instead of `volume:$uid`. 


### Related issues
#45 
