### PR TITLE
changes in source mode not saved - fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Fixed a bug where CKEditor 4 stopped working when used within a Matrix block, if the block was moved to a new position. ([#23](https://github.com/craftcms/ckeditor/issues/23)) 
+- Fixed a bug where changes made in source mode weren’t saved unless additional changes were made in WYSIWYG mode afterward. ([#34](https://github.com/craftcms/ckeditor/pull/56))
 
 ## 1.4.0 - 2022-12-16
 - Added RTL language support. ([#33](https://github.com/craftcms/ckeditor/issues/33), [#55](https://github.com/craftcms/ckeditor/pull/55))

--- a/src/assets/field/dist/init.js
+++ b/src/assets/field/dist/init.js
@@ -7,6 +7,18 @@ async function initCkeditor(id, init) {
       editor.on('change', () => {
         editor.updateElement();
       });
+
+      // Keep the source element updated with changes when in source mode too;
+      // change event only fires in wysiwyg mode:
+      // https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-change
+      editor.on('mode', function() {
+        if (this.mode === 'source') {
+          const editable = editor.editable();
+          editable.attachListener(editable, 'input', function() {
+            editor.updateElement();
+          });
+        }
+      });
     };
     const deinit = function() {
       if (typeof CKEDITOR.instances[id] !== 'undefined') {


### PR DESCRIPTION
### Description
When editing content in the source mode and saving from the source mode, changes were not being saved. This only applies to CKEditor v4.

It turns out CKEditor only fires the `change` event whilst in WYSIWYG mode. Additional provisions were needed to update the editor with the changes when in source mode: https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-change

This can also be released for the `main` branch (tested there too).

### Related issues
#34 
