### PR TITLE
fix - CKE dying when e.g. matrix block is dragged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes for CKEditor for Craft CMS
 
+## Unreleased
+- Fixed a bug where CKEditor 4 stopped working when used within a Matrix block, if the block was moved to a new position. ([#23](https://github.com/craftcms/ckeditor/issues/23)) 
+
 ## 1.4.0 - 2022-12-16
 - Added RTL language support. ([#33](https://github.com/craftcms/ckeditor/issues/33), [#55](https://github.com/craftcms/ckeditor/pull/55))
 

--- a/src/assets/field/dist/init.js
+++ b/src/assets/field/dist/init.js
@@ -25,10 +25,10 @@ async function initCkeditor(id, init) {
 
     // https://github.com/craftcms/ckeditor/issues/23
     // for when using "move up" and "move down" menu options
-    Garnish.on(Garnish.Base, 'beforeMoveUp beforeMoveDown', deinit);
-    Garnish.on(Garnish.Base, 'moveUp moveDown', realInit);
+    Garnish.on(Craft.MatrixInput, 'beforeMoveBlockUp beforeMoveBlockDown', deinit);
+    Garnish.on(Craft.MatrixInput, 'moveBlockUp moveBlockDown', realInit);
     // for when dragging and dropping
-    Garnish.on(Garnish.BaseDrag, 'dragStop', null, function() {
+    Garnish.on(Craft.MatrixInput, 'blockSortDragStop', null, function() {
       deinit();
       realInit();
     });

--- a/src/assets/field/dist/init.js
+++ b/src/assets/field/dist/init.js
@@ -22,6 +22,16 @@ async function initCkeditor(id, init) {
     Garnish.on(Craft.Preview, 'open close', realInit);
     Garnish.on(Craft.LivePreview, 'beforeEnter beforeExit', deinit);
     Garnish.on(Craft.LivePreview, 'enter exit', realInit);
+
+    // https://github.com/craftcms/ckeditor/issues/23
+    // for when using "move up" and "move down" menu options
+    Garnish.on(Garnish.Base, 'beforeMoveUp beforeMoveDown', deinit);
+    Garnish.on(Garnish.Base, 'moveUp moveDown', realInit);
+    // for when dragging and dropping
+    Garnish.on(Garnish.BaseDrag, 'dragStop', null, function() {
+      deinit();
+      realInit();
+    });
   } else {
     // CKEditor 5
     try {


### PR DESCRIPTION
### Description
When CKE is in, e.g. a matrix block and that block is dragged to a different position (or Move up/down buttons are used), the editor dies. The solution to this is reinitialising the editor.

There’s an accompanying PR for the CMS project that’s needed for this to work with the move up/down menu options: [#12498](https://github.com/craftcms/cms/pull/12498)

This fix can be applied to the `main` branch too.

### Related issues
#23 
