### PR TITLE
Bugfix/13112 soft brakes field marked as modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for CKEditor for Craft CMS
 
+## Unreleased
+
+- Fixed a bug where fields with `<br>` tags would always appear dirty. ([#85](https://github.com/craftcms/ckeditor/issues/85))
+
 ## 3.2.1 - 2023-04-23
 
 - Fixed an error that occurred when a CKEditor field was used in Quick Post widgets.

--- a/src/Field.php
+++ b/src/Field.php
@@ -345,6 +345,19 @@ JS,
     }
 
     /**
+     * @inheritdoc
+     */
+    protected function prepValueForInput($value, ?ElementInterface $element): string
+    {
+        // This is needed because CKEditor5 insists on <br>
+        // and HTMLPurifier prefers to go with <br />
+        // That clash causes this issue: https://github.com/craftcms/cms/issues/13112
+        $value = str_replace(['<br />', '<br/>'], '<br>', $value);
+
+        return parent::prepValueForInput($value, $element);
+    }
+
+    /**
      * Returns the link options available to the field.
      *
      * Each link option is represented by an array with the following keys:

--- a/src/helpers/CkeditorConfigSchema.php
+++ b/src/helpers/CkeditorConfigSchema.php
@@ -25,7 +25,7 @@ final class CkeditorConfigSchema
                             [
                                 'type' => 'object',
                                 'properties' => [
-                                    'classNaame' => ['type' => 'string'],
+                                    'className' => ['type' => 'string'],
                                     'name' => ['interface' => 'SupportedOption'],
                                 ],
                                 'required' => ['className', 'name'],


### PR DESCRIPTION
### Description
When getting the field input value, change all the `<br />` and `<br/>` tags to `<br>` so that the field doesn’t get marked as changed by simply getting in focus.

CKEditor insists on `<br>`, and HTMLPurifier insists on `<br />`.

I have also bundled in fixing a type-o in the config schema.


### Related issues
https://github.com/craftcms/ckeditor/issues/85
