### PR TITLE
Add missing translation in German

### DIFF
--- a/src/translations/de/ckeditor.php
+++ b/src/translations/de/ckeditor.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'Insert link' => 'Link einfügen',
     'Link to an entry' => 'Link zu einem Eintrag',
     'Link to an asset' => 'Link zu einer Datei',
     'Link to a category' => 'Link zu einer Kategorie',


### PR DESCRIPTION
### Description

Add a missing translation for the button label _Insert link_ in German.

### Related issues

#111 