### PR TITLE
conditionally allow style attribute for ul and ol tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for CKEditor for Craft CMS
 
+## Unreleased
+
+- HTML Purifier is now configured to allow `style` attributes on `<ol>` and `<ul>` tags, when bulleted/numbered lists are allowed. ([#136](https://github.com/craftcms/ckeditor/issues/136))
+
 ## 3.5.1 - 2023-08-29
 
 - Fixed a bug where CKEditor inputs weren’t getting any padding within slideouts. ([#126](https://github.com/craftcms/ckeditor/issues/126)) 

--- a/src/Field.php
+++ b/src/Field.php
@@ -849,6 +849,18 @@ JS,
             ]);
         }
 
+        if (in_array('numberedList', $ckeConfig->toolbar)) {
+            /** @var HTMLPurifier_HTMLDefinition|null $def */
+            $def = $purifierConfig->getDefinition('HTML', true);
+            $def?->addAttribute('ol', 'style', 'Text');
+        }
+
+        if (in_array('bulletedList', $ckeConfig->toolbar)) {
+            /** @var HTMLPurifier_HTMLDefinition|null $def */
+            $def = $purifierConfig->getDefinition('HTML', true);
+            $def?->addAttribute('ul', 'style', 'Text');
+        }
+
         return $purifierConfig;
     }
 }


### PR DESCRIPTION
### Description
Allows the `style` attribute on `ol` and `ul` tags if the numbered list and bulleted lists are added via CKEditor config (respectively).


### Related issues
#136 
