### PR TITLE
prevent constant reopen of slideout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for CKEditor for Craft CMS
 
+## Unreleased
+
+- Fixed a bug where the CKEditor config-creation slideout could keep reappearing if canceled. ([#138](https://github.com/craftcms/ckeditor/pull/138))
+
 ## 3.6.0 - 2023-09-13
 
 - CKEditor is now released under the GPL-3.0 license.

--- a/src/templates/_field-settings.twig
+++ b/src/templates/_field-settings.twig
@@ -16,6 +16,9 @@
           });
         });
         slideout.on('close', () => {
+          if (selectize.lastValidValue === '__add__') {
+            selectize.lastValidValue = '';
+          }
           selectize.focus();
         });
       }


### PR DESCRIPTION
### Description
If you go to field settings and choose the `Create a new` option for the “CKEditor Config”, close the slideout (without saving) and click anywhere on the page, the slideout will reopen. You can only stop this by reloading a page or using tab to switch focus to a different field. This behaviour is linked to the `select_on_focus` plugin. Fixed by clearing the `lastValidValue` for selectize.

Related PR for the CMS: https://github.com/craftcms/cms/pull/13716

### Related issues
https://github.com/craftcms/cms/issues/13707
