### PR TITLE
show custom element sources in CKE link to {type}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Link element selector modals now include custom sources. ([#139](https://github.com/craftcms/ckeditor/issues/139))
 - Fixed a bug where the CKEditor config-creation slideout could keep reappearing if canceled. ([#138](https://github.com/craftcms/ckeditor/pull/138))
 - Fixed a conflict with `nystudio107/craft-code-editor` 1.0.14 and 1.0.15. ([#150](https://github.com/craftcms/ckeditor/issues/150)) 
 

--- a/src/Field.php
+++ b/src/Field.php
@@ -29,6 +29,7 @@ use craft\models\CategoryGroup;
 use craft\models\ImageTransform;
 use craft\models\Section;
 use craft\models\Volume;
+use craft\services\ElementSources;
 use craft\web\View;
 use HTMLPurifier_Config;
 use HTMLPurifier_HTMLDefinition;
@@ -668,6 +669,7 @@ JS,
                 'elementType' => Category::class,
                 'refHandle' => Category::refHandle(),
                 'sources' => $categorySources,
+                'criteria' => ['uri' => ':notempty:'],
             ];
         }
 
@@ -732,12 +734,20 @@ JS,
             }
         }
 
+        $sources = array_values(array_unique($sources));
+
         if ($showSingles) {
             array_unshift($sources, 'singles');
         }
 
         if (!empty($sources)) {
             array_unshift($sources, '*');
+        }
+
+        // include custom sources
+        $customSources = $this->_getCustomSources(Entry::class);
+        if (!empty($customSources)) {
+            $sources = array_merge($sources, $customSources);
         }
 
         return $sources;
@@ -755,11 +765,19 @@ JS,
             return [];
         }
 
-        return Collection::make(Craft::$app->getCategories()->getAllGroups())
+        $sources = Collection::make(Craft::$app->getCategories()->getAllGroups())
             ->filter(fn(CategoryGroup $group) => $group->getSiteSettings()[$element->siteId]?->hasUrls ?? false)
             ->map(fn(CategoryGroup $group) => "group:$group->uid")
             ->values()
             ->all();
+
+        // include custom sources
+        $customSources = $this->_getCustomSources(Category::class);
+        if (!empty($customSources)) {
+            $sources = array_merge($sources, $customSources);
+        }
+
+        return $sources;
     }
 
     /**
@@ -784,10 +802,37 @@ JS,
             $volumes = $volumes->filter(fn(Volume $volume) => $userService->checkPermission("viewAssets:$volume->uid"));
         }
 
-        return $volumes
+        $sources = $volumes
             ->map(fn(Volume $volume) => "volume:$volume->uid")
             ->values()
             ->all();
+
+        // include custom sources
+        $customSources = $this->_getCustomSources(Asset::class);
+        if (!empty($customSources)) {
+            $sources = array_merge($sources, $customSources);
+        }
+
+        return $sources;
+    }
+
+    /**
+     * Returns custom element sources keys for given element type.
+     *
+     * @param string $elementType
+     * @return array
+     */
+    private function _getCustomSources(string $elementType): array
+    {
+        $customSources = [];
+        $elementSources = Craft::$app->getElementSources()->getSources($elementType, 'modal');
+        foreach ($elementSources as $elementSource) {
+            if ($elementSource['type'] === ElementSources::TYPE_CUSTOM && isset($elementSource['key'])) {
+                $customSources[] = $elementSource['key'];
+            }
+        }
+
+        return $customSources;
     }
 
     /**


### PR DESCRIPTION
### Description
Show custom element sources in the link to the entry/category/asset modal.

For custom sources, we don’t have a way of knowing if the elements in that source have URLs or not (so essentially if they can be linked to or not), but the `'criteria' => ['uri' => ':notempty:'],` takes care of hiding any elements that don’t have a link. So technically, there’s a chance that custom element sources will show in the modal’s sidebar, but there will be no elements to choose from in them.

If approved, I’ll create a PR for Commerce, too.


### Related issues
#139 
