### PR TITLE
one more adjustment for revisions

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -11,6 +11,7 @@ use Craft;
 use craft\base\Element;
 use craft\ckeditor\web\assets\BaseCkeditorPackageAsset;
 use craft\ckeditor\web\assets\ckeditor\CkeditorAsset;
+use craft\elements\Entry;
 use craft\elements\NestedElementManager;
 use craft\events\AssetBundleEvent;
 use craft\events\ModelEvent;
@@ -101,6 +102,8 @@ class Plugin extends \craft\base\Plugin
                 // and all other "standard" conditions are met (see Entry::_shouldSaveRevision())
                 // create the revision
                 if (
+                    $element instanceof Entry &&
+                    !Craft::$app->getRequest()->isConsoleRequest &&
                     $element->getPrimaryOwnerId() === null &&
                     $element->id &&
                     !$element->propagating &&

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -96,6 +96,20 @@ class Plugin extends \craft\base\Plugin
                 foreach ($this->entryManagers($element) as $entryManager) {
                     $entryManager->maintainNestedElements($element, $event->isNew);
                 }
+            } else {
+                // if we are resaving, and it's an owner element,
+                // and all other "standard" conditions are met (see Entry::_shouldSaveRevision())
+                // create the revision
+                if (
+                    $element->getPrimaryOwnerId() === null &&
+                    $element->id &&
+                    !$element->propagating &&
+                    !$element->getIsDraft() &&
+                    !$element->getIsRevision() &&
+                    $element->getSection()?->enableVersioning
+                ) {
+                    Craft::$app->getRevisions()->createRevision($element);
+                }
             }
         });
 


### PR DESCRIPTION
### Description
Commit https://github.com/craftcms/ckeditor/commit/bb50647b4c4cc2c5feb6ef945ca4861396a93eb6 fixes the issue where multiple revisions were being created if the CKE field has nested entries, but it also prevents the revision of being created at all. This addition ensures a revision is created when the owner entry is fully saved.


### Related issues

