### PR TITLE
parse refs for front-end

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -1007,6 +1007,11 @@ JS,
             $value = $this->_prepNestedEntriesForDisplay($value, $element?->siteId, $static);
         }
 
+        // @see https://github.com/craftcms/ckeditor/issues/197
+        if (!$this->isCpRequest()) {
+            $value = Craft::$app->getElements()->parseRefs($value, $element?->siteId);
+        }
+
         return parent::prepValueForInput($value, $element);
     }
 


### PR DESCRIPTION
### Description
Parse content refs for the front end so that the links to elements don’t have hashes like`#entry:77@1:url` at the end.


### Related issues
#197 
