### PR TITLE
Bugfix/nested entries in revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for CKEditor for Craft CMS
 
+## Unreleased
+
+- Fixed a bug where nested entries weren’t visible when viewing revisions. ([#227](https://github.com/craftcms/ckeditor/issues/227))
+- Fixed a bug where nested entry cards were getting rendered after page load. ([#221](https://github.com/craftcms/ckeditor/discussions/221))
+
 ## 4.0.4 - 2024-04-25
 
 - Fixed a bug where front-end links included element reference URL fragments. ([#197](https://github.com/craftcms/ckeditor/issues/197))

--- a/src/Field.php
+++ b/src/Field.php
@@ -1004,10 +1004,9 @@ JS,
             // (https://github.com/craftcms/ckeditor/issues/96)
             $value = $this->_normalizeFigures($value);
 
-            // without this, nested entries won't show in revisions
-            if ($static) {
-                $value = $this->_prepNestedEntriesForDisplay($value, $element?->siteId, $static);
-            }
+            // without this, nested entries won't show in revisions;
+            // not including it, also causes a layout shift when editing in the CP
+            $value = $this->_prepNestedEntriesForDisplay($value, $element?->siteId, $static);
         }
 
         return parent::prepValueForInput($value, $element);

--- a/src/Field.php
+++ b/src/Field.php
@@ -1003,6 +1003,11 @@ JS,
             // Redactor to CKEditor syntax for <figure>
             // (https://github.com/craftcms/ckeditor/issues/96)
             $value = $this->_normalizeFigures($value);
+
+            // without this, nested entries won't show in revisions
+            if ($static) {
+                $value = $this->_prepNestedEntriesForDisplay($value, $element?->siteId, $static);
+            }
         }
 
         return parent::prepValueForInput($value, $element);


### PR DESCRIPTION
### Description
It turns out I can replicate https://github.com/craftcms/ckeditor/issues/227 in a standard, simple way, after all.

One of the changes made for #197 is preventing the nested entries from rendering in revisions. It’s also what causes the layout shift described [here](https://github.com/craftcms/ckeditor/discussions/221).

Bringing back the call to `_prepNestedEntriesForDisplay()` when preparing value for input fixes both cases.


### Related issues

