### PR TITLE
Allow modifying of the toolbar items

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -368,6 +368,7 @@ class Field extends HtmlField
         $event = new ModifyConfigEvent([
             'baseConfig' => $baseConfig,
             'ckeConfig' => $ckeConfig,
+            'toolbar' => $toolbar,
         ]);
         $this->trigger(self::EVENT_MODIFY_CONFIG, $event);
 
@@ -389,7 +390,7 @@ JS;
         }
 
         $baseConfigJs = Json::encode($event->baseConfig);
-        $toolbarJs = Json::encode($toolbar);
+        $toolbarJs = Json::encode($event->toolbar);
         $languageJs = Json::encode([
             'ui' => BaseCkeditorPackageAsset::uiLanguage(),
             'content' => $element?->getSite()->language ?? Craft::$app->language,

--- a/src/events/ModifyConfigEvent.php
+++ b/src/events/ModifyConfigEvent.php
@@ -27,4 +27,9 @@ class ModifyConfigEvent extends Event
      * @var CkeConfig $ckeConfig The CKEditor config
      */
     public CkeConfig $ckeConfig;
+
+    /**
+     * @var array<string> $toolbar The toolbar config
+     */
+    public array $toolbar;
 }


### PR DESCRIPTION
### Description

In addition to allowing plugins to modify the `Field`'s configurations (`baseConfig` and `ckeConfig`), it would be great to have a way of influencing the toolbar's layout before registering the view's JS.
I believe simply adding `toolbar` to the `ModifyConfigEvent` solves this requirement without requiring much additional effort. 