### PR TITLE
Iterable field data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Entry cards now display provisional changes, with an “Edited” label.
+- It’s now possible to loop over CKEditor field values from templates, which will split the value into chunks representing HTML markup and nested entry entries. ([#241](https://github.com/craftcms/ckeditor/pull/241))
 - CKEditor now requires Craft CMS 5.2+.
 - Fixed a bug where nested entry edit pages could have a “Delete for site” action.
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   },
   "require": {
     "php": "^8.2",
-    "craftcms/cms": "^5.2.0-beta.1",
+    "craftcms/cms": "5.2.x-dev as 5.2.0",
     "craftcms/html-field": "^3.1.0",
     "nystudio107/craft-code-editor": ">=1.0.8 <=1.0.13 || ^1.0.16"
   },

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   "require": {
     "php": "^8.2",
     "craftcms/cms": "^5.0.0-beta.7",
-    "craftcms/html-field": "^3.0.0-alpha",
+    "craftcms/html-field": "^3.1.0",
     "nystudio107/craft-code-editor": ">=1.0.8 <=1.0.13 || ^1.0.16"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "25ea7faabacb1cb513f580b9a429801e",
+    "content-hash": "290145aef2e5d1384e7f9a296a10d9cc",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -457,16 +457,16 @@
         },
         {
             "name": "craftcms/html-field",
-            "version": "3.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/craftcms/html-field.git",
-                "reference": "54f6e6178b696d5b7bb886631e161293b73d565e"
+                "reference": "34a5796c74e22d4ae80709541367114d03d280ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/craftcms/html-field/zipball/54f6e6178b696d5b7bb886631e161293b73d565e",
-                "reference": "54f6e6178b696d5b7bb886631e161293b73d565e",
+                "url": "https://api.github.com/repos/craftcms/html-field/zipball/34a5796c74e22d4ae80709541367114d03d280ca",
+                "reference": "34a5796c74e22d4ae80709541367114d03d280ca",
                 "shasum": ""
             },
             "require": {
@@ -502,7 +502,7 @@
                 "rss": "https://github.com/craftcms/html-field/commits/main.atom",
                 "source": "https://github.com/craftcms/html-field"
             },
-            "time": "2024-03-06T18:17:06+00:00"
+            "time": "2024-06-11T14:58:59+00:00"
         },
         {
             "name": "craftcms/plugin-installer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5b3d16374b89e1b46f35b293f4e10ac3",
+    "content-hash": "12cccbc09cb9183031c796e5762e6fc1",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -331,16 +331,16 @@
         },
         {
             "name": "craftcms/cms",
-            "version": "5.2.0-beta.5",
+            "version": "5.2.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/craftcms/cms.git",
-                "reference": "8db60d936d9e7d60a0c8ee8dd7b8af561723c524"
+                "reference": "f6c9b112de446781abdcc7e589260c0d71535881"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/craftcms/cms/zipball/8db60d936d9e7d60a0c8ee8dd7b8af561723c524",
-                "reference": "8db60d936d9e7d60a0c8ee8dd7b8af561723c524",
+                "url": "https://api.github.com/repos/craftcms/cms/zipball/f6c9b112de446781abdcc7e589260c0d71535881",
+                "reference": "f6c9b112de446781abdcc7e589260c0d71535881",
                 "shasum": ""
             },
             "require": {
@@ -456,7 +456,7 @@
                 "rss": "https://github.com/craftcms/cms/releases.atom",
                 "source": "https://github.com/craftcms/cms"
             },
-            "time": "2024-06-08T14:32:56+00:00"
+            "time": "2024-06-12T12:46:29+00:00"
         },
         {
             "name": "craftcms/html-field",
@@ -7695,10 +7695,17 @@
             "time": "2023-11-12T22:43:29+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "craftcms/cms",
+            "version": "5.2.9999999.9999999-dev",
+            "alias": "5.2.0",
+            "alias_normalized": "5.2.0.0"
+        }
+    ],
     "minimum-stability": "stable",
     "stability-flags": {
-        "craftcms/cms": 10,
+        "craftcms/cms": 20,
         "craftcms/ecs": 20,
         "craftcms/phpstan": 20,
         "craftcms/rector": 20

--- a/src/Field.php
+++ b/src/Field.php
@@ -21,7 +21,6 @@ use craft\ckeditor\events\DefineLinkOptionsEvent;
 use craft\ckeditor\events\ModifyConfigEvent;
 use craft\ckeditor\web\assets\BaseCkeditorPackageAsset;
 use craft\ckeditor\web\assets\ckeditor\CkeditorAsset;
-use craft\controllers\GraphqlController;
 use craft\db\FixedOrderExpression;
 use craft\db\Query;
 use craft\db\Table;

--- a/src/data/BaseChunk.php
+++ b/src/data/BaseChunk.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license MIT
+ */
+
+namespace craft\ckeditor\data;
+
+use yii\base\BaseObject;
+
+/**
+ * Represents a chunk of CKEditor content.
+ *
+ * @property-read string $type
+ * @property-read string $html
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.1.0
+ */
+abstract class BaseChunk extends BaseObject
+{
+    abstract public function getType(): string;
+    abstract public function getHtml(): string;
+
+    public function __toString(): string
+    {
+        return $this->getHtml();
+    }
+}

--- a/src/data/BaseChunk.php
+++ b/src/data/BaseChunk.php
@@ -8,6 +8,7 @@
 
 namespace craft\ckeditor\data;
 
+use craft\web\twig\SafeHtml;
 use yii\base\BaseObject;
 
 /**
@@ -18,7 +19,7 @@ use yii\base\BaseObject;
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 4.1.0
  */
-abstract class BaseChunk extends BaseObject
+abstract class BaseChunk extends BaseObject implements SafeHtml
 {
     abstract public function getType(): string;
     abstract public function getHtml(): string;

--- a/src/data/Entry.php
+++ b/src/data/Entry.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license MIT
+ */
+
+namespace craft\ckeditor\data;
+
+use craft\elements\Entry as EntryElement;
+
+/**
+ * Represents an entry within a CKEditor field’s content.
+ *
+ * @property EntryElement|null $entry
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.1.0
+ */
+class Entry extends BaseChunk
+{
+    private ?EntryElement $entry;
+
+    public function __construct(
+        public readonly int $entryId,
+        private readonly FieldData $fieldData,
+    ) {
+    }
+
+    public function getType(): string
+    {
+        return 'entry';
+    }
+
+    public function getHtml(): string
+    {
+        return $this->getEntry()?->render() ?? '';
+    }
+
+    public function getEntry(): ?EntryElement
+    {
+        $this->fieldData->loadEntries();
+        return $this->entry;
+    }
+
+    public function setEntry(?EntryElement $entry): void
+    {
+        $this->entry = $entry;
+    }
+}

--- a/src/data/FieldData.php
+++ b/src/data/FieldData.php
@@ -12,7 +12,6 @@ use ArrayIterator;
 use Countable;
 use Craft;
 use craft\elements\Entry as EntryElement;
-use craft\helpers\ElementHelper;
 use craft\helpers\Html;
 use craft\htmlfield\HtmlFieldData;
 use Illuminate\Support\Collection;

--- a/src/data/FieldData.php
+++ b/src/data/FieldData.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license MIT
+ */
+
+namespace craft\ckeditor\data;
+
+use ArrayIterator;
+use Countable;
+use Craft;
+use craft\elements\Entry as EntryElement;
+use craft\helpers\Html;
+use craft\htmlfield\HtmlFieldData;
+use Illuminate\Support\Collection;
+use IteratorAggregate;
+use Traversable;
+use Twig\Markup as TwigMarkup;
+
+/**
+ * Stores the data for CKEditor fields.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.1.0
+ */
+class FieldData extends HtmlFieldData implements IteratorAggregate, Countable
+{
+    /**
+     * @var Collection<BaseChunk>
+     */
+    private Collection $chunks;
+    private bool $loadedEntries = false;
+    private bool $rendered = false;
+
+    /**
+     * @inheritdoc
+     * @noinspection PhpMissingParentConstructorInspection
+     */
+    public function __construct(string $content, ?int $siteId = null)
+    {
+        $this->rawContent = $content;
+        $this->siteId = $siteId;
+    }
+
+    public function __toString()
+    {
+        $this->render();
+        return parent::__toString();
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->getChunks()->all());
+    }
+
+    public function count(): int
+    {
+        return $this->getChunks()->count();
+    }
+
+    public function jsonSerialize()
+    {
+        $this->render();
+        return parent::jsonSerialize();
+    }
+
+    /**
+     * Returns a collection of the content chunks.
+     *
+     * @param bool $loadEntries
+     * @return Collection<BaseChunk>
+     */
+    public function getChunks(bool $loadEntries = true): Collection
+    {
+        $this->parse();
+
+        if ($loadEntries) {
+            $this->loadEntries();
+            return $this->chunks
+                ->filter(fn(BaseChunk $chunk) => !$chunk instanceof Entry || $chunk->getEntry() !== null);
+        }
+
+        return $this->chunks;
+    }
+
+    private function parse(): void
+    {
+        if (isset($this->chunks)) {
+            return;
+        }
+
+        $this->chunks = Collection::make();
+        $offset = 0;
+
+        while (($pos = stripos($this->rawContent, '<craft-entry', $offset)) !== false) {
+            $gtPos = strpos($this->rawContent, '>', $pos + 12);
+            if ($gtPos === false) {
+                break;
+            }
+
+            $this->addContentChunk(substr($this->rawContent, $offset, $pos - $offset));
+
+            $attributes = Html::parseTagAttributes($this->rawContent, $pos);
+            if (!empty($attributes['data']['entry-id'])) {
+                $this->chunks->push(new Entry($attributes['data']['entry-id'], $this));
+            }
+
+            $offset = $gtPos + 1;
+
+            $closePos = stripos($this->rawContent, '</craft-entry>', $offset);
+            if ($closePos !== false) {
+                $offset = $closePos + 14;
+            }
+        }
+
+        $this->addContentChunk($offset ? substr($this->rawContent, $offset) : $this->rawContent);
+    }
+
+    private function addContentChunk(string $content): void
+    {
+        if ($content === '') {
+            return;
+        }
+
+        $lastChunk = $this->chunks->last();
+
+        if ($lastChunk instanceof Markup) {
+            $lastChunk->rawHtml .= $content;
+        } else {
+            $this->chunks->push(new Markup($content, $this->siteId));
+        }
+    }
+
+    public function loadEntries(): void
+    {
+        if ($this->loadedEntries) {
+            return;
+        }
+
+        $this->parse();
+        $entryChunks = $this->chunks->filter(fn(BaseChunk $chunk) => $chunk instanceof Entry);
+        $entryIds = $entryChunks->map(fn(Entry $chunk) => $chunk->entryId)->all();
+
+        if (!empty($entryIds)) {
+            $entries = EntryElement::find()
+                ->id($entryIds)
+                ->siteId($this->siteId)
+                ->status(null)
+                ->drafts(null)
+                ->revisions(null)
+                ->trashed(null)
+                ->indexBy('id')
+                ->all();
+        } else {
+            $entries = [];
+        }
+
+        $entryChunks->each(function(Entry $chunk) use ($entries) {
+            $chunk->setEntry($entries[$chunk->entryId] ?? null);
+        });
+
+        $this->loadedEntries = true;
+    }
+
+    private function render(): void
+    {
+        if ($this->rendered) {
+            return;
+        }
+
+        $content = $this->getChunks()->map(fn(BaseChunk $chunk) => $chunk->getHtml())->join('');
+        TwigMarkup::__construct($content, Craft::$app->charset);
+
+        $this->rendered = true;
+    }
+}

--- a/src/data/Markup.php
+++ b/src/data/Markup.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license MIT
+ */
+
+namespace craft\ckeditor\data;
+
+use Craft;
+
+/**
+ * Represents HTML markup within a CKEditor field’s content.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.1.0
+ */
+class Markup extends BaseChunk
+{
+    private string $html;
+
+    public function __construct(
+        public string $rawHtml,
+        private readonly int $siteId,
+    ) {
+    }
+
+    public function getType(): string
+    {
+        return 'markup';
+    }
+
+    public function getHtml(): string
+    {
+        if (!isset($this->html)) {
+            $this->html = Craft::$app->getElements()->parseRefs($this->rawHtml, $this->siteId);
+        }
+        return $this->html;
+    }
+}

--- a/src/translations/fr/ckeditor.php
+++ b/src/translations/fr/ckeditor.php
@@ -4,5 +4,5 @@ return [
     'Link to a category' => 'Lien vers une catégorie',
     'Link to an entry' => 'Lien vers une entrée',
     'Link to an asset' => 'Lien vers une ressource',
-    'Insert link' => 'Insérer un lien'
+    'Insert link' => 'Insérer un lien',
 ];


### PR DESCRIPTION
### Description

Makes it possible to loop over CKEditor field values, which will split the value into chunks representing either HTML markup or nested entries.

```twig
{% for chunk in entry.myCkeditorField %}
  {% if chunk.type == 'markup' %}
    <div class="markup">
      {{ chunk }}
    </div>
  {% else %}
    <div class="entry" data-entry-id="{{ chunk.entry.id }}">
      {{ chunk }}
    </div>
  {% endif %}
{% endfor %}
```

Outputting nested entry chunks directly will render their partial templates. Alternatively, you could call the entry’s `render()` method explicitly if you want to pass custom variables to the partial template:

```twig
{{ chunk.entry.render({
  foo: 'bar',
}) }}
```

Or bypass the partial template entirely:

```twig
{% switch chunk.entry.type.handle %}
  {% case 'text' %}
    <p>{{ chunk.entry.myTextField }}</p>
  {% case 'img' %}
    {% set asset = chunk.entry.myAssetsField.eagerly().one() %}
    {% if asset %}
      {{ asset.getImg({ width: 500 }) }}
    {% endif %}
{% endswitch %}
```

### Related issues

- #238
- craftcms/cms#15178