### PR TITLE
show provisional changes after exiting from source mode too

### DIFF
--- a/src/translations/fr/ckeditor.php
+++ b/src/translations/fr/ckeditor.php
@@ -4,5 +4,5 @@ return [
     'Link to a category' => 'Lien vers une catégorie',
     'Link to an entry' => 'Lien vers une entrée',
     'Link to an asset' => 'Lien vers une ressource',
-    'Insert link' => 'Insérer un lien'
+    'Insert link' => 'Insérer un lien',
 ];


### PR DESCRIPTION
### Description
If, in your CKEditor field, you have a nested entry with the “edited” flag, and you go into source mode, make a change (e.g. add space to some text) and go out of source mode, the “edited” flag is lost. (If you then open the nested entry for editing, you see it as a provisional draft with all the changes you previously made.)

Fix: attempt to get the provisional draft first when rendering the card via `CkeditorController::actionEntryCardHtml()`.


### Related issues
n/a
