### PR TITLE
render nested entries for static html

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -1046,20 +1046,22 @@ JS,
                     $entry = $entries[$chunk->entryId];
 
                     try {
-                        if ($static) {
-                            return $this->getCardHtml($entry);
-                        } else {
-                            return Html::tag('craft-entry', options: [
-                                'data' => [
-                                    'entry-id' => $entry->isProvisionalDraft ? $entry->getCanonicalId() : $entry->id,
-                                    'card-html' => $this->getCardHtml($entry),
-                                ],
-                            ]);
-                        }
+                        $cardHtml = $this->getCardHtml($entry);
                     } catch (InvalidConfigException) {
                         // this can happen e.g. when the entry type has been deleted
                         return '';
                     }
+
+                    if ($static) {
+                        return $cardHtml;
+                    }
+
+                    return Html::tag('craft-entry', options: [
+                        'data' => [
+                            'entry-id' => $entry->isProvisionalDraft ? $entry->getCanonicalId() : $entry->id,
+                            'card-html' => $cardHtml,
+                        ],
+                    ]);
                 })
                 ->join('');
         }

--- a/src/Field.php
+++ b/src/Field.php
@@ -1046,7 +1046,9 @@ JS,
                     $entry = $entries[$chunk->entryId];
 
                     try {
-                        if (!$static) {
+                        if ($static) {
+                            return $this->getCardHtml($entry);
+                        } else {
                             return Html::tag('craft-entry', options: [
                                 'data' => [
                                     'entry-id' => $entry->isProvisionalDraft ? $entry->getCanonicalId() : $entry->id,

--- a/src/Field.php
+++ b/src/Field.php
@@ -1034,7 +1034,10 @@ JS,
                 ->keyBy(fn(EntryChunk $chunk) => $chunk->entryId)
                 ->map(fn(EntryChunk $chunk) => $chunk->getEntry())
                 ->all();
-            ElementHelper::swapInProvisionalDrafts($entries);
+
+            if (!$static) {
+                ElementHelper::swapInProvisionalDrafts($entries);
+            }
 
             $value = $chunks
                 ->map(function(BaseChunk $chunk) use ($static, $entries) {


### PR DESCRIPTION
### Description
Render nested entries when displaying static html.

Before:
<img width="1721" alt="Screenshot 2024-06-12 at 14 58 56" src="https://github.com/craftcms/ckeditor/assets/4500340/1f8009fa-fb8e-4ad2-aa47-3a5bc5a614b6">

After:
<img width="1721" alt="Screenshot 2024-06-12 at 14 58 44" src="https://github.com/craftcms/ckeditor/assets/4500340/8d844db6-2424-4c49-a39c-ddf4f3feef80">



### Related issues

