### PR TITLE
only render nested entries if they're live

### DIFF
--- a/src/data/Entry.php
+++ b/src/data/Entry.php
@@ -34,7 +34,13 @@ class Entry extends BaseChunk
 
     public function getHtml(): string
     {
-        return $this->getEntry()?->render() ?? '';
+        $entry = $this->getEntry();
+
+        if (!$entry || $entry->getStatus() !== EntryElement::STATUS_LIVE) {
+            return '';
+        }
+
+        return $entry->render();
     }
 
     public function getEntry(): ?EntryElement

--- a/src/data/Entry.php
+++ b/src/data/Entry.php
@@ -36,7 +36,7 @@ class Entry extends BaseChunk
     {
         $entry = $this->getEntry();
 
-        if (!$entry || $entry->getStatus() !== EntryElement::STATUS_LIVE) {
+        if ($entry?->getStatus() !== EntryElement::STATUS_LIVE) {
             return '';
         }
 


### PR DESCRIPTION
### Description
Only render nested entries (in the front end) if they’re live.

CP view:
<img width="1723" alt="Screenshot 2024-06-12 at 16 21 02" src="https://github.com/craftcms/ckeditor/assets/4500340/3b80981f-71e7-48e8-9661-2d7723c5533e">

Before:
<img width="385" alt="Screenshot 2024-06-12 at 16 20 02" src="https://github.com/craftcms/ckeditor/assets/4500340/74659d06-bb54-4c3c-9453-d20eab1ecd26">


After:
<img width="454" alt="Screenshot 2024-06-12 at 16 19 50" src="https://github.com/craftcms/ckeditor/assets/4500340/0e6bee75-059d-4627-9640-4fbc7a79dd9d">



### Related issues
#246 
