### PR TITLE
Improve spacing issues in UI

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -358,7 +358,7 @@ class Field extends HtmlField
             'ui' => [
                 'viewportOffset' => ['top' => 50],
                 'poweredBy' => [
-                    'position' => 'inside',
+                    'position' => 'outside',
                     'label' => '',
                 ],
             ],

--- a/src/web/assets/ckeditor/src/ckeditor5-craftcms.css
+++ b/src/web/assets/ckeditor/src/ckeditor5-craftcms.css
@@ -84,6 +84,10 @@ a.ck.ck-button:focus {
 }
 
 /* content */
+.ck.ck-content ul:last-child {
+  padding-bottom: 0 !important;
+}
+
 .ck.ck-content[dir='ltr'] ul {
   padding-left: 40px;
 }

--- a/src/web/assets/ckeditor/src/ckeditor5-craftcms.css
+++ b/src/web/assets/ckeditor/src/ckeditor5-craftcms.css
@@ -84,7 +84,7 @@ a.ck.ck-button:focus {
 }
 
 /* content */
-.ck.ck-content ul:last-child {
+.ck.ck-content ol:last-child, .ck.ck-content ul:last-child {
   padding-bottom: 0 !important;
 }
 

--- a/src/web/assets/ckeditor/src/ckeditor5-craftcms.css
+++ b/src/web/assets/ckeditor/src/ckeditor5-craftcms.css
@@ -50,11 +50,7 @@ a.ck.ck-button:focus {
 }
 
 .ck.ck-editor__editable_inline {
-  padding: calc(var(--m) - 2px) var(--m)
-    calc(
-      var(--m) + var(--ck-powered-by-line-height) +
-        var(--ck-powered-by-padding-vertical)
-    ) !important;
+  padding: calc(var(--m) - 2px) var(--m) !important;
 }
 
 .ck.ck-editor__editable.ck-focused:not(.ck-editor__nested-editable) {

--- a/src/web/assets/ckeditor/src/ckeditor5-craftcms.css
+++ b/src/web/assets/ckeditor/src/ckeditor5-craftcms.css
@@ -84,7 +84,7 @@ a.ck.ck-button:focus {
 }
 
 /* content */
-.ck.ck-content ol:last-child, .ck.ck-content ul:last-child {
+.ck.ck-content ul:last-child, .ck.ck-content ol:last-child {
   padding-bottom: 0 !important;
 }
 


### PR DESCRIPTION
This PR addresses spacing issues that regularly results in rogue trailing lines. It is based on the work of [@devolute](https://mastodon.social/@devolute):
https://mastodon.social/@devolute/112615852011105973

1. Sets the CKEditor branding to `outside`.
2. Equalises vertical padding.
3. Forces 0 padding after the last child in a list.

Before:

<img width="462" alt="1be25a9b6ca46937" src="https://github.com/craftcms/ckeditor/assets/57572400/c5106b8a-f34f-4e20-89e9-ccc744191830">

After:

<img width="462" alt="949df88befc41946" src="https://github.com/craftcms/ckeditor/assets/57572400/fa0a8e03-cc05-42ff-95cc-eec7ddbd29a2">