### PR TITLE
normalize pre tags after redactor conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added `craft\ckeditor\events\ModifyConfigEvent::$toolbar`. ([#233](https://github.com/craftcms/ckeditor/pull/233))
+- Fixed a bug where code blocks created by a Redactor field only had `<pre>` tags with no `<code>` tags inside them. ([#258](https://github.com/craftcms/ckeditor/issues/258))
 
 ## 3.8.3 - 2024-03-28
 

--- a/src/Field.php
+++ b/src/Field.php
@@ -647,7 +647,7 @@ JS,
             }
 
             $preContent = Html::tag('code', $preContent, [
-                'class' => 'language-plaintext'
+                'class' => 'language-plaintext',
             ]);
 
             $value = substr($value, 0, $startPos) . $preContent . substr($value, $endPos);


### PR DESCRIPTION
### Description
Redactor and CKEditor use slightly different markup for code block content. Redactor wraps such content in a `<pre>` tag, while CKEditor requires `<pre><code class="language-{langId}">` by default. This means that all `<pre>` tags that are not followed by a `<code>` tag need to be normalised to contain them. 

To prevent this normalisation from interfering with custom configuration of the CKEditor [code block feature](https://ckeditor.com/docs/ckeditor5/latest/features/code-blocks.html), the code will only convert `<pre>` to `<pre><code class="language-plaintext">` if the `<pre>` tag is not immediately followed by the `<code>` tag.

Original Redactor field:
<img width="1045" alt="Screenshot 2024-06-25 at 12 21 39" src="https://github.com/craftcms/ckeditor/assets/4500340/9cb6317c-4020-46dd-9d3d-a9acc3340970">

Redactor field converted to a CKEditor field before this PR:
<img width="1049" alt="Screenshot 2024-06-25 at 12 21 15" src="https://github.com/craftcms/ckeditor/assets/4500340/cc013ba9-79aa-41ee-854a-274df79c5f70">

Redactor field converted to a CKEditor field with this PR:
<img width="1054" alt="Screenshot 2024-06-25 at 12 21 00" src="https://github.com/craftcms/ckeditor/assets/4500340/dd2856f6-368b-48e7-8fde-dc407cc6ed9d">


### Related issues
#258 
