### PR TITLE
converting from Redactor - `htmlSupport` predefined options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- CKEditor configs created via the `ckeditor/convert` command now allow modifying HTML attributes, classes, and styles within the source view, if the Redactor config included the `html` button. ([#264](https://github.com/craftcms/ckeditor/pull/264), [#263](https://github.com/craftcms/ckeditor/issues/263))
 - Added `craft\ckeditor\events\ModifyConfigEvent::$toolbar`. ([#233](https://github.com/craftcms/ckeditor/pull/233))
 - Fixed a bug where code blocks created by a Redactor field only had `<pre>` tags with no `<code>` tags inside them. ([#258](https://github.com/craftcms/ckeditor/issues/258))
 

--- a/src/console/controllers/ConvertController.php
+++ b/src/console/controllers/ConvertController.php
@@ -207,7 +207,7 @@ class ConvertController extends Controller
                         throw new Exception('`manualConfig` contains invalid JSON.');
                     }
                     $configName = $field['name'] ?? (!empty($field['handle']) ? Inflector::camel2words($field['handle']) : 'Untitled');
-                    $ckeConfig = $this->generateCkeConfig($configName, $redactorConfig, $ckeConfigs, $fieldSettingsByConfig);
+                    $ckeConfig = $this->generateCkeConfig($configName, $redactorConfig, $ckeConfigs, $fieldSettingsByConfig, $field);
                     $this->stdout(PHP_EOL);
                 } else {
                     $basename = ($field['settings']['redactorConfig'] ?? $field['settings']['configFile'] ?? null) ?: 'Default.json';
@@ -347,6 +347,7 @@ class ConvertController extends Controller
         array $redactorConfig,
         array &$ckeConfigs,
         array &$fieldSettingsByConfig,
+        ?array $redactorField = null,
     ): string {
         // Make sure the name is unique
         $baseConfigName = $configName;
@@ -667,6 +668,22 @@ class ConvertController extends Controller
                     }
                 }
             }
+        }
+
+        // if we added sourceEditing button, then to align with what Redactor allowed,
+        // we need add this predefined htmlSupport.allow config
+        if ($ckeConfig->hasButton('sourceEditing')) {
+            $htmlSupport = [
+                'attributes' => true,
+                'classes' => true,
+                'styles' => true,
+            ];
+
+            if ($redactorField !== null && $redactorField['settings']['removeInlineStyles']) {
+                unset($htmlSupport['styles']);
+            }
+
+            $ckeConfig->options['htmlSupport']['allow'][] = $htmlSupport;
         }
 
         // redactor-link-styles


### PR DESCRIPTION
### Description
When converting fields from Redactor to CKEditor, if you have the “html” button in your Redactor config, it’ll get “translated” into the “sourceEditing” button in the CKEditor field. Since Redactor allowed classes, attributes, and styles to be added via the HTML editing mode (provided HTML Purifier was configured to support them, too), CKEditor should also allow those.


### Related issues
#263
