### PR TITLE
`sourceEditingGroups` can be null too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for CKEditor for Craft CMS
 
+## Unreleased
+
+- Fixed an error that occurred if the “Who should see the ‘Source’ button?” field setting was totally blank. ([#359](https://github.com/craftcms/ckeditor/issues/359))
+
 ## 3.11.0 - 2025-01-23
 
 - CKEditor fields no longer have extra bottom padding, and the CKEditor logo is now displayed over the bottom border. ([#252](https://github.com/craftcms/ckeditor/pull/252))

--- a/src/Field.php
+++ b/src/Field.php
@@ -585,6 +585,10 @@ JS,
             return true;
         }
 
+        if ($this->sourceEditingGroups === null) {
+            return false;
+        }
+
         $sourceEditingGroups = array_flip($this->sourceEditingGroups);
 
         if ($user->admin && isset($sourceEditingGroups['__ADMINS__'])) {


### PR DESCRIPTION
### Description
Fixes an issue that occurred when no groups were selected for the CKEditor field under “Who should see the “Source” button?”.


### Related issues
#359 
