### PR TITLE
Return false when sourceEditingGroups is null

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -1205,6 +1205,10 @@ JS,
             return true;
         }
 
+        if ($this->sourceEditingGroups === null) {
+            return false;
+        }
+
         $sourceEditingGroups = array_flip($this->sourceEditingGroups);
 
         if ($user->admin && isset($sourceEditingGroups['__ADMINS__'])) {


### PR DESCRIPTION
### Description
Fixes an issue that occurred when no groups were selected for the CKEditor field under “Who should see the “Source” button?”. Same as https://github.com/craftcms/ckeditor/pull/364 but for `4.x` branch.

### Related issues
https://github.com/craftcms/ckeditor/issues/359
