### PR TITLE
don't hyperlink card's title and don't show the pencil icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 4.6.0 - 2025-02-18
 
+- Nested entry cards no longer have edit buttons within their toolbars, or hyperlink their titles. ([#387](https://github.com/craftcms/ckeditor/pull/387))
 - Added the ability to override entry type names and handles for CKEditor fields. ([#369](https://github.com/craftcms/ckeditor/discussions/369))
 - CKEditor fields now show provisional drafts for nested entries when previewing an owner element. ([#340](https://github.com/craftcms/ckeditor/pull/340))
 - Fixed an error that occurred if the “Who should see the ‘Source’ button?” field setting was totally blank. ([#359](https://github.com/craftcms/ckeditor/issues/359))

--- a/src/Field.php
+++ b/src/Field.php
@@ -788,6 +788,8 @@ class Field extends HtmlField implements ElementContainerFieldInterface, Mergeab
             'attributes' => [
                 'class' => array_filter([$isRevision ? 'cke-entry-card' : null]),
             ],
+            'hyperlink' => false,
+            'showEditButton' => false,
         ]);
     }
 


### PR DESCRIPTION
### Description
We should stop hyperlinking the card’s title and not show the edit icon once the changes from https://github.com/craftcms/cms/pull/16983 are released.


### Related issues
https://github.com/craftcms/cms/pull/16983
