### PR TITLE
entry manager per field instance

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -162,8 +162,8 @@ class Field extends HtmlField implements ElementContainerFieldInterface, Mergeab
      */
     public static function entryManager(self $field): NestedElementManager
     {
-        if (!isset(self::$entryManagers[$field->id])) {
-            self::$entryManagers[$field->id] = $entryManager = new NestedElementManager(
+        if (!isset(self::$entryManagers[$field->layoutElement->uid])) {
+            self::$entryManagers[$field->layoutElement->uid] = $entryManager = new NestedElementManager(
                 Entry::class,
                 fn(ElementInterface $owner) => self::createEntryQuery($owner, $field),
                 [
@@ -253,7 +253,7 @@ class Field extends HtmlField implements ElementContainerFieldInterface, Mergeab
             );
         }
 
-        return self::$entryManagers[$field->id];
+        return self::$entryManagers[$field->layoutElement->uid];
     }
 
     private static function fieldInstances(ElementInterface $element, self $field): array

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -125,8 +125,8 @@ class Plugin extends \craft\base\Plugin
         $entryManagers = [];
         $customFields = $element->getFieldLayout()?->getCustomFields() ?? [];
         foreach ($customFields as $field) {
-            if ($field instanceof Field && !isset($entryManagers[$field->id])) {
-                $entryManagers[$field->id] = Field::entryManager($field);
+            if ($field instanceof Field && !isset($entryManagers[$field->layoutElement->uid])) {
+                $entryManagers[$field->layoutElement->uid] = Field::entryManager($field);
             }
         }
         return array_values($entryManagers);


### PR DESCRIPTION
### Description
**Issue:**
Saving nested element changes against the owner’s draft doesn’t work as expected with multi-instance fields.


https://github.com/user-attachments/assets/09bbf153-5ed7-42d2-b299-ca6d3a6e5b56



**Steps to reproduce:**
- CMS 5.6+ and CKEditor 4.6.0
- create a `text` entry type; it can contain simply the default title
- create a CKEditor config with the “New entry” button and select `text` entry type under “Entry Types”
- create a CKEditor field that uses this config
- create a section (all default settings) with a new entry type that has two instances of the CKEditor field from the previous step included twice
- create an entry in this section, in each CKE field add one nested entry & fully save everything
- edit the nested entry in the second cke field on the page, save and then save the root entry - changes are discarded when the root element is saved
- swap the fields around in the entry type
- edit the nested entry in the second cke field on the page, save and then save the root entry - changes are discarded when the root element is saved
- if you edit whichever field is first on the page, it’ll work as expected, regardless of whether it has an overwritten handle or not

**Solution:**
Create nested element manager on per-instance basis.


### Related issues
n/a, reported by @tommysvr 
