### PR TITLE
Window monacoeditor instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Added `craft\ckeditor\gql\CkeditorMarkup`.
 - Added `craft\ckeditor\gql\Generator`.
 - Fixed a bug where it wasn’t easily possible to drag a toolbar button to the last position in the toolbar, if that meant wrapping the buttons to a new row.
+- Fixed a JavaScript error that could prevent the toolbar configurator from loading, when editing a CKEditor config within a slideout. ([#401](https://github.com/craftcms/ckeditor/pull/401))
 
 ## 4.7.0 - 2025-04-21
 

--- a/src/web/assets/ckeconfig/CkeConfigAsset.php
+++ b/src/web/assets/ckeconfig/CkeConfigAsset.php
@@ -9,9 +9,7 @@ namespace craft\ckeditor\web\assets\ckeconfig;
 
 use craft\ckeditor\web\assets\ckeditor\CkeditorAsset;
 use craft\web\AssetBundle;
-use craft\web\View;
 use nystudio107\codeeditor\assetbundles\codeeditor\CodeEditorAsset;
-use nystudio107\codeeditor\CodeEditor;
 
 /**
  * CKEditor custom build asset bundle

--- a/src/web/assets/ckeconfig/CkeConfigAsset.php
+++ b/src/web/assets/ckeconfig/CkeConfigAsset.php
@@ -9,6 +9,9 @@ namespace craft\ckeditor\web\assets\ckeconfig;
 
 use craft\ckeditor\web\assets\ckeditor\CkeditorAsset;
 use craft\web\AssetBundle;
+use craft\web\View;
+use nystudio107\codeeditor\assetbundles\codeeditor\CodeEditorAsset;
+use nystudio107\codeeditor\CodeEditor;
 
 /**
  * CKEditor custom build asset bundle
@@ -26,6 +29,7 @@ class CkeConfigAsset extends AssetBundle
      * @inheritdoc
      */
     public $depends = [
+        CodeEditorAsset::class,
         CkeditorAsset::class,
     ];
 


### PR DESCRIPTION
Create an explicit dependency on `CodeEditorAsset` because `CkeConfigAsset` needs it to have created [`window.monacoEditorInstances`](https://github.com/nystudio107/craft-code-editor/blob/adb724e86dd3812b6b4f553fa0208fedfbfa4866/src/web/assets/src/js/code-editor.ts#L121-L124) before it can [add to the object](https://github.com/craftcms/ckeditor/blob/d273347b1afb59ff03fa422f8eca0c6656eba753/src/web/assets/ckeconfig/src/ConfigOptions.js#L26-L27). 

