### PR TITLE
Full GraphQL data mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,19 @@
 
 ## Unreleased
 
-- Added the “Field Limit” setting, which can be set to a character limit or word limit. ([#384](https://github.com/craftcms/ckeditor/pull/384))
+- Added the “Field Limit” field setting, which can be set to a character limit or word limit. ([#384](https://github.com/craftcms/ckeditor/pull/384))
+- Added the “GraphQL Mode” field setting. ([#403](https://github.com/craftcms/ckeditor/pull/403))
 - Improved the styling of CKEditor fields. ([craftcms/cms#17164](https://github.com/craftcms/cms/discussions/17164))
 - The “Anchors” CKEditor plugin has been replaced with CKEditor’s new built-in [Bookmarks](https://ckeditor.com/docs/ckeditor5/latest/features/bookmarks.html) plugin. ([#397](https://github.com/craftcms/ckeditor/pull/397))
 - Updated to CKEditor 5 45.0.0. ([#397](https://github.com/craftcms/ckeditor/pull/397))
 - Added `craft\ckeditor\Field::$characterLimit`.
+- Added `craft\ckeditor\Field::$fullGraphqlData`.
+- Added `craft\ckeditor\data\FieldData::getEntries()`.
+- Added `craft\ckeditor\data\Markup::getMarkdown()`.
+- Added `craft\ckeditor\data\Markup::getPlainText()`.
+- Added `craft\ckeditor\gql\CkeditorData`.
+- Added `craft\ckeditor\gql\CkeditorMarkup`.
+- Added `craft\ckeditor\gql\Generator`.
 - Fixed a bug where it wasn’t easily possible to drag a toolbar button to the last position in the toolbar, if that meant wrapping the buttons to a new row.
 
 ## 4.7.0 - 2025-04-21

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   "require": {
     "php": "^8.2",
     "craftcms/cms": "^5.6.0",
-    "craftcms/html-field": "^3.1.0",
+    "craftcms/html-field": "^3.4.0",
     "nystudio107/craft-code-editor": ">=1.0.8 <=1.0.13 || ^1.0.16"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a9d81de1129e73d28dc327c272754da0",
+    "content-hash": "e390ace889471e8e0d50bb18e0dc426a",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -458,22 +458,24 @@
         },
         {
             "name": "craftcms/html-field",
-            "version": "3.3.0",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/craftcms/html-field.git",
-                "reference": "aeb5f149fc4e46aeacae40c5ff3d5f1f9d7818b0"
+                "reference": "3f23569c94d64e9054e3402447e03bd3c4c7b181"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/craftcms/html-field/zipball/aeb5f149fc4e46aeacae40c5ff3d5f1f9d7818b0",
-                "reference": "aeb5f149fc4e46aeacae40c5ff3d5f1f9d7818b0",
+                "url": "https://api.github.com/repos/craftcms/html-field/zipball/3f23569c94d64e9054e3402447e03bd3c4c7b181",
+                "reference": "3f23569c94d64e9054e3402447e03bd3c4c7b181",
                 "shasum": ""
             },
             "require": {
                 "craftcms/cms": "^5.5.0",
                 "league/html-to-markdown": "^5.1",
-                "php": "^8.2"
+                "php": "^8.2",
+                "symfony/css-selector": "^6.0|^7.0",
+                "symfony/dom-crawler": "^6.0|^7.0"
             },
             "require-dev": {
                 "craftcms/ecs": "dev-main",
@@ -504,7 +506,7 @@
                 "rss": "https://github.com/craftcms/html-field/commits/main.atom",
                 "source": "https://github.com/craftcms/html-field"
             },
-            "time": "2025-04-28T21:48:36+00:00"
+            "time": "2025-04-30T16:54:07+00:00"
         },
         {
             "name": "craftcms/plugin-installer",

--- a/src/Field.php
+++ b/src/Field.php
@@ -20,6 +20,7 @@ use craft\ckeditor\data\FieldData;
 use craft\ckeditor\data\Markup;
 use craft\ckeditor\events\DefineLinkOptionsEvent;
 use craft\ckeditor\events\ModifyConfigEvent;
+use craft\ckeditor\gql\Generator;
 use craft\ckeditor\web\assets\BaseCkeditorPackageAsset;
 use craft\ckeditor\web\assets\ckeditor\CkeditorAsset;
 use craft\db\FixedOrderExpression;
@@ -56,6 +57,7 @@ use craft\models\Section;
 use craft\models\Volume;
 use craft\services\ElementSources;
 use craft\web\View;
+use GraphQL\Type\Definition\Type;
 use HTMLPurifier_Config;
 use HTMLPurifier_Exception;
 use HTMLPurifier_HTMLDefinition;
@@ -440,6 +442,12 @@ class Field extends HtmlField implements ElementContainerFieldInterface, Mergeab
     public ?string $createButtonLabel = null;
 
     /**
+     * @var bool Whether GraphQL values should be returned as objects with `content`, `chunks`, etc., sub-fields.
+     * @since 4.7.0
+     */
+    public bool $fullGraphqlData = true;
+
+    /**
      * @var EntryType[] The field’s available entry types
      * @see getEntryTypes()
      * @see setEntryTypes()
@@ -476,6 +484,15 @@ class Field extends HtmlField implements ElementContainerFieldInterface, Mergeab
 
         if (isset($config['entryTypes']) && $config['entryTypes'] === '') {
             $config['entryTypes'] = [];
+        }
+
+        if (isset($config['graphqlMode'])) {
+            $config['fullGraphqlData'] = ArrayHelper::remove($config, 'graphqlMode') === 'full';
+        }
+
+        // Default fullGraphqlData to false for existing fields
+        if (isset($config['id']) && !isset($config['fullGraphqlData'])) {
+            $config['fullGraphqlData'] = false;
         }
 
         parent::__construct($config);
@@ -557,6 +574,18 @@ class Field extends HtmlField implements ElementContainerFieldInterface, Mergeab
         }
 
         return $rules;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getContentGqlType(): Type|array
+    {
+        if (!$this->fullGraphqlData) {
+            return parent::getContentGqlType();
+        }
+
+        return Generator::generateType($this);
     }
 
     /**

--- a/src/Field.php
+++ b/src/Field.php
@@ -443,7 +443,7 @@ class Field extends HtmlField implements ElementContainerFieldInterface, Mergeab
 
     /**
      * @var bool Whether GraphQL values should be returned as objects with `content`, `chunks`, etc., sub-fields.
-     * @since 4.7.0
+     * @since 4.8.0
      */
     public bool $fullGraphqlData = true;
 

--- a/src/data/FieldData.php
+++ b/src/data/FieldData.php
@@ -11,6 +11,7 @@ namespace craft\ckeditor\data;
 use ArrayIterator;
 use Countable;
 use Craft;
+use craft\elements\db\EntryQuery;
 use craft\elements\Entry as EntryElement;
 use craft\helpers\Html;
 use craft\htmlfield\HtmlFieldData;
@@ -18,6 +19,7 @@ use Illuminate\Support\Collection;
 use IteratorAggregate;
 use Traversable;
 use Twig\Markup as TwigMarkup;
+use yii\base\UnknownPropertyException;
 
 /**
  * Stores the data for CKEditor fields.
@@ -48,6 +50,15 @@ class FieldData extends HtmlFieldData implements IteratorAggregate, Countable
     {
         $this->render();
         return parent::__toString();
+    }
+
+    public function __get(string $name)
+    {
+        return match ($name) {
+            'chunks' => $this->getChunks(),
+            'entries' => $this->getEntries(),
+            default => throw new UnknownPropertyException(sprintf('Getting unknown property: %s::%s', static::class, $name)),
+        };
     }
 
     public function getIterator(): Traversable
@@ -135,38 +146,51 @@ class FieldData extends HtmlFieldData implements IteratorAggregate, Countable
         }
     }
 
+    /**
+     * Returns an entry query prepped to fetch the nested entries.
+     *
+     * @return EntryQuery
+     * @since 4.8.0
+     */
+    public function getEntries(): EntryQuery
+    {
+        $this->parse();
+        $entryChunks = $this->chunks->filter(fn(BaseChunk $chunk) => $chunk instanceof Entry);
+        $entryIds = $entryChunks->map(fn(Entry $chunk) => $chunk->entryId)->all();
+        $query = EntryElement::find();
+
+        if (!empty($entryIds)) {
+            $query
+                ->id($entryIds)
+                ->siteId($this->siteId)
+                ->status(null)
+                ->drafts(null)
+                ->revisions(null)
+                ->trashed(null);
+
+            if (Craft::$app->getRequest()->getIsPreview()) {
+                $query->withProvisionalDrafts();
+            }
+        } else {
+            $query->id(false);
+        }
+
+        return $query;
+    }
+
     public function loadEntries(): void
     {
         if ($this->loadedEntries) {
             return;
         }
 
-        $this->parse();
         $entryChunks = $this->chunks->filter(fn(BaseChunk $chunk) => $chunk instanceof Entry);
-        $entryIds = $entryChunks->map(fn(Entry $chunk) => $chunk->entryId)->all();
-
-        if (!empty($entryIds)) {
-            $query = EntryElement::find()
-                ->id($entryIds)
-                ->siteId($this->siteId)
-                ->status(null)
-                ->drafts(null)
-                ->revisions(null)
-                ->trashed(null)
-                ->indexBy('id');
-
-            if (Craft::$app->getRequest()->getIsPreview()) {
-                $query->withProvisionalDrafts();
-            }
-
-            $entries = $query->all();
-        } else {
-            $entries = [];
+        if (!empty($entryChunks)) {
+            $entries = $this->getEntries()->indexBy('id')->all();
+            $entryChunks->each(function(Entry $chunk) use ($entries) {
+                $chunk->setEntry($entries[$chunk->entryId] ?? null);
+            });
         }
-
-        $entryChunks->each(function(Entry $chunk) use ($entries) {
-            $chunk->setEntry($entries[$chunk->entryId] ?? null);
-        });
 
         $this->loadedEntries = true;
     }

--- a/src/data/FieldData.php
+++ b/src/data/FieldData.php
@@ -57,7 +57,7 @@ class FieldData extends HtmlFieldData implements IteratorAggregate, Countable
         return match ($name) {
             'chunks' => $this->getChunks(),
             'entries' => $this->getEntries(),
-            default => throw new UnknownPropertyException(sprintf('Getting unknown property: %s::%s', static::class, $name)),
+            default => parent::__get($name),
         };
     }
 

--- a/src/data/FieldData.php
+++ b/src/data/FieldData.php
@@ -185,7 +185,7 @@ class FieldData extends HtmlFieldData implements IteratorAggregate, Countable
         }
 
         $entryChunks = $this->chunks->filter(fn(BaseChunk $chunk) => $chunk instanceof Entry);
-        if (!empty($entryChunks)) {
+        if ($entryChunks->isNotEmpty()) {
             $entries = $this->getEntries()->indexBy('id')->all();
             $entryChunks->each(function(Entry $chunk) use ($entries) {
                 $chunk->setEntry($entries[$chunk->entryId] ?? null);

--- a/src/data/FieldData.php
+++ b/src/data/FieldData.php
@@ -19,7 +19,6 @@ use Illuminate\Support\Collection;
 use IteratorAggregate;
 use Traversable;
 use Twig\Markup as TwigMarkup;
-use yii\base\UnknownPropertyException;
 
 /**
  * Stores the data for CKEditor fields.

--- a/src/data/Markup.php
+++ b/src/data/Markup.php
@@ -9,6 +9,7 @@
 namespace craft\ckeditor\data;
 
 use Craft;
+use craft\htmlfield\HtmlFieldData;
 use League\HTMLToMarkdown\HtmlConverter;
 use yii\base\UnknownPropertyException;
 
@@ -59,12 +60,7 @@ class Markup extends BaseChunk
      */
     public function getMarkdown(array $config = []): string
     {
-        $converter = new HtmlConverter([
-            'header_style' => 'atx',
-            'remove_nodes' => 'meta style script',
-            ...$config,
-        ]);
-        return $converter->convert($this->getHtml());
+        return HtmlFieldData::toMarkdown($this->getHtml(), $config);
     }
 
     /**
@@ -75,15 +71,7 @@ class Markup extends BaseChunk
      */
     public function getPlainText(): string
     {
-        $text = $this->getMarkdown([
-            'strip_tags' => true,
-            'strip_placeholder_links' => true,
-            'hard_break' => true,
-        ]);
-
-        // remove heading chars
-        $text = preg_replace('/^#* /m', '', $text);
-
-        return $text;
+        // link href's and images get removed, so no need to run the HTML through parseRefs()
+        return HtmlFieldData::toPlainText($this->rawHtml);
     }
 }

--- a/src/gql/CkeditorData.php
+++ b/src/gql/CkeditorData.php
@@ -24,6 +24,7 @@ class CkeditorData extends ObjectType
     {
         /** @var FieldData $source */
         $fieldName = $resolveInfo->fieldName;
+        /** @phpstan-ignore-next-line */
         return match ($fieldName) {
             'html' => $source->getParsedContent(),
             'rawHtml' => $source->getRawContent(),

--- a/src/gql/CkeditorData.php
+++ b/src/gql/CkeditorData.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license GPL-3.0-or-later
+ */
+
+namespace craft\ckeditor\gql;
+
+use craft\ckeditor\data\FieldData;
+use craft\gql\base\ObjectType;
+use craft\gql\resolvers\elements\Entry as EntryResolver;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * GraphQL data type
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.8.0
+ */
+class CkeditorData extends ObjectType
+{
+    protected function resolve(mixed $source, array $arguments, mixed $context, ResolveInfo $resolveInfo): mixed
+    {
+        /** @var FieldData $source */
+        $fieldName = $resolveInfo->fieldName;
+        return match ($fieldName) {
+            'html' => $source->getParsedContent(),
+            'rawHtml' => $source->getRawContent(),
+            'markdown' => $source->getMarkdown($arguments),
+            'plainText' => $source->getPlainText(),
+            'entries' => EntryResolver::resolve($source, $arguments, $context, $resolveInfo),
+        };
+    }
+}

--- a/src/gql/CkeditorMarkup.php
+++ b/src/gql/CkeditorMarkup.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license GPL-3.0-or-later
+ */
+
+namespace craft\ckeditor\gql;
+
+use craft\ckeditor\data\Markup;
+use craft\gql\base\ObjectType;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * Markup GraphQL data type
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.8.0
+ */
+class CkeditorMarkup extends ObjectType
+{
+    protected function resolve(mixed $source, array $arguments, mixed $context, ResolveInfo $resolveInfo): mixed
+    {
+        /** @var Markup $source */
+        return match ($resolveInfo->fieldName) {
+            'html' => $source->getHtml(),
+            'rawHtml' => $source->rawHtml,
+            'markdown' => $source->getMarkdown($arguments),
+            'plainText' => $source->getPlainText(),
+        };
+    }
+}

--- a/src/gql/CkeditorMarkup.php
+++ b/src/gql/CkeditorMarkup.php
@@ -22,6 +22,7 @@ class CkeditorMarkup extends ObjectType
     protected function resolve(mixed $source, array $arguments, mixed $context, ResolveInfo $resolveInfo): mixed
     {
         /** @var Markup $source */
+        /** @phpstan-ignore-next-line */
         return match ($resolveInfo->fieldName) {
             'html' => $source->getHtml(),
             'rawHtml' => $source->rawHtml,

--- a/src/gql/Generator.php
+++ b/src/gql/Generator.php
@@ -21,6 +21,7 @@ use craft\gql\base\SingleGeneratorInterface;
 use craft\gql\GqlEntityRegistry;
 use craft\gql\types\generators\EntryType as EntryTypeGenerator;
 use craft\helpers\Gql;
+use craft\htmlfield\HtmlFieldData;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 
@@ -72,7 +73,7 @@ class Generator implements GeneratorInterface, SingleGeneratorInterface
                     ],
                     'remove_nodes' => [
                         'type' => Type::string(),
-                        'description' => 'Space-separated list of tag names that should be removed (`"meta style script"` by default).',
+                        'description' => sprintf('Space-separated list of tag names that should be removed (`"%s"` by default).', HtmlFieldData::BASE_MARKDOWN_CONFIG['remove_nodes']),
                     ],
                     'hard_break' => [
                         'type' => Type::boolean(),

--- a/src/gql/Generator.php
+++ b/src/gql/Generator.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license GPL-3.0-or-later
+ */
+
+namespace craft\ckeditor\gql;
+
+use Craft;
+use craft\ckeditor\data\BaseChunk;
+use craft\ckeditor\data\Entry;
+use craft\ckeditor\data\FieldData;
+use craft\ckeditor\data\Markup;
+use craft\ckeditor\Field;
+use craft\elements\Entry as EntryElement;
+use craft\gql\arguments\elements\Entry as EntryArguments;
+use craft\gql\base\GeneratorInterface;
+use craft\gql\base\ObjectType;
+use craft\gql\base\SingleGeneratorInterface;
+use craft\gql\GqlEntityRegistry;
+use craft\gql\types\generators\EntryType as EntryTypeGenerator;
+use craft\helpers\Gql;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\Type;
+
+/**
+ * GraphQL data type generator
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.8.0
+ */
+class Generator implements GeneratorInterface, SingleGeneratorInterface
+{
+    public static function generateTypes(mixed $context = null): array
+    {
+        return [static::generateType($context)];
+    }
+
+    public static function generateType(mixed $context): ObjectType
+    {
+        /** @var Field $context */
+        $handle = $context->layoutElement?->getOriginalHandle() ?? $context->handle;
+        $typeName = "{$handle}_CkeditorField";
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new CkeditorData([
+            'name' => $typeName,
+            'fields' => function() use ($context, $typeName) {
+                $entryTypes = EntryTypeGenerator::generateTypes($context);
+                $entryArgs = EntryArguments::getArguments();
+                $gqlService = Craft::$app->getGql();
+
+                foreach ($context->getEntryTypes() as $entryType) {
+                    $entryArgs += $gqlService->getFieldLayoutArguments($entryType->getFieldLayout());
+                }
+
+                $markdownArgs = [
+                    'header_style' => [
+                        'type' => Type::string(),
+                        'description' => 'Set to `"setext"` to output H1 and H2 headers using the `===` syntax.',
+                    ],
+                    'suppress_errors' => [
+                        'type' => Type::boolean(),
+                        'description' => 'Set to `false` to show warnings when loading malformed HTML.',
+                    ],
+                    'strip_tags' => [
+                        'type' => Type::boolean(),
+                        'description' => 'Set to `true` to strip tags that don’t have Markdown equivalents.',
+                    ],
+                    'strip_placeholder_links' => [
+                        'type' => Type::boolean(),
+                        'description' => 'Set to `true` to remove `<a>` tags that don’t have `href` attributes.',
+                    ],
+                    'remove_nodes' => [
+                        'type' => Type::string(),
+                        'description' => 'Space-separated list of tag names that should be removed (`"meta style script"` by default).',
+                    ],
+                    'hard_break' => [
+                        'type' => Type::boolean(),
+                        'description' => 'Set to `true` to turn `<br>` into `\n` instead of `  \n`.',
+                    ],
+                    'list_item_style' => [
+                        'type' => Type::string(),
+                        'description' => 'Set the default character for each `<li>` in a `<ul>`. Can be `"-"`, `"*"`, or `"+"`.',
+                    ],
+                    'preserve_comments' => [
+                        'type' => Type::boolean(),
+                        'description' => 'Set to `true` to preserve comments.',
+                    ],
+                    'use_autolinks' => [
+                        'type' => Type::boolean(),
+                        'description' => 'Set to `false` to always use the `[]()` link syntax.',
+                    ],
+                    'table_pipe_escape' => [
+                        'type' => Type::string(),
+                        'description' => 'String for pipe characters inside Markdown table cells (`"\\\|"` by default).',
+                    ],
+                    'table_caption_side' => [
+                        'type' => Type::string(),
+                        'description' => 'Set to `"bottom"` to show `<caption>` content after tables.',
+                    ],
+                ];
+
+                $fields = [
+                    'html' => [
+                        'type' => Type::string(),
+                        'description' => 'The parsed content as HTML.',
+                    ],
+                    'rawHtml' => [
+                        'type' => Type::string(),
+                        'description' => 'The raw HTML value, with reference tags and `<craft-entry>` nodes in-tact.',
+                    ],
+                    'markdown' => [
+                        'type' => Type::string(),
+                        'description' => 'The parsed content as Markdown.',
+                        'args' => $markdownArgs,
+                    ],
+                    'plainText' => [
+                        'type' => Type::string(),
+                        'description' => 'The parsed content as plain text.',
+                    ],
+                    'entries' => [
+                        'type' => Type::nonNull(Type::listOf(Gql::getUnionType("{$typeName}_entries", $entryTypes))),
+                        'description' => 'The nested entries within the content.',
+                        'args' => $entryArgs,
+                    ],
+                    'chunks' => [
+                        'type' => Type::nonNull(Type::listOf(Gql::getUnionType("{$typeName}_chunks", [
+                            ...$entryTypes,
+                            'CkeditorMarkup' => GqlEntityRegistry::getOrCreate('CkeditorMarkup', fn() => new CkeditorMarkup([
+                                'name' => 'CkeditorMarkup',
+                                'fields' => fn() => [
+                                    'html' => [
+                                        'type' => Type::string(),
+                                        'description' => 'The parsed chunk value as HTML.',
+                                    ],
+                                    'rawHtml' => [
+                                        'type' => Type::string(),
+                                        'description' => 'The raw chunk HTML value, with reference tags in-tact.',
+                                    ],
+                                    'markdown' => [
+                                        'type' => Type::string(),
+                                        'description' => 'The parsed chunk value as Markdown.',
+                                        'args' => $markdownArgs,
+                                    ],
+                                    'plainText' => [
+                                        'type' => Type::string(),
+                                        'description' => 'The parsed chunk value as plain text..',
+                                    ],
+                                ],
+                            ])),
+                        ], function(Markup|EntryElement $value) {
+                            return $value instanceof EntryElement ? $value->getGqlTypeName() : 'CkeditorMarkup';
+                        }))),
+                        'description' => 'The content split into chunks of markup and nested entries.',
+                        'resolve' => function(mixed $source, array $arguments, mixed $context, ResolveInfo $resolveInfo) {
+                            /** @var FieldData $source */
+                            return array_map(function(BaseChunk $chunk) {
+                                if ($chunk instanceof Entry) {
+                                    return $chunk->getEntry();
+                                }
+                                /** @var Markup $chunk */
+                                return $chunk;
+                            }, $source->getChunks()->all());
+                        },
+                    ],
+                ];
+
+                return Craft::$app->getGql()->prepareFieldDefinitions($fields, $typeName);
+            },
+        ]));
+    }
+}

--- a/src/templates/_field-settings.twig
+++ b/src/templates/_field-settings.twig
@@ -167,4 +167,17 @@
       value: field.purifierConfig
     }) }}
   </div>
+
+  {% if craft.app.config.general.enableGql %}
+    {{ forms.selectField({
+      label: 'GraphQL Mode'|t('app'),
+      id: 'graphql-mode',
+      name: 'graphqlMode',
+      options: [
+        {label: 'Full data'|t('app'), value: 'full'},
+        {label: 'Raw content only'|t('ckeditor'), value: 'raw'},
+      ],
+      value: field.fullGraphqlData ? 'full' : 'raw',
+    }) }}
+  {% endif %}
 </div>

--- a/src/translations/en/ckeditor.php
+++ b/src/translations/en/ckeditor.php
@@ -34,6 +34,7 @@ return [
     'Link to the current site' => 'Link to the current site',
     'No transform' => 'No transform',
     'Purify HTML' => 'Purify HTML',
+    'Raw content only' => 'Raw content only',
     'Removes any potentially-malicious code on save, by running the submitted data through {link}.' => 'Removes any potentially-malicious code on save, by running the submitted data through {link}.',
     'Show word count' => 'Show word count',
     'Site: {name}' => 'Site: {name}',


### PR DESCRIPTION
### Description

Adds a new “GraphQL Mode” setting to CKEditor fields, with “Full data” and “Raw content only” options. (Existing fields will get “Raw content only” selected by default; new fields will get “Full data” selected by default.)

When “Full data” is selected, the field will define a robust GraphQL content schema, providing full access to nested entry data, as well as more control over how HTML markup is retrieved, via the following sub-fields:

- `html` – The parsed content as HTML
- `rawHtml` - The raw HTML value, with reference tags and `<craft-entry>` nodes in-tact
- `markdown` – The parsed content as Markdown
- `plainText` – The parsed content as plain text
- `entries` – The nested entries within the content (with support for entry query arguments)
- `chunks` – The content split into chunks of markup (`CkeditorMarkup`) and nested entries (`<entryTypeHandle>_Entry`)

### Example

```graphql
query {
  entries(section: "mySection") {
    ...on myEntryType_Entry {
      myCkeditorField {
        html
        rawHtml @parseRefs
        markdown (header_style: "setext")
        plainText
        entries(type: "link") {
          ...on myNestedEntryType_Entry {
            # …
          }
        }
        chunks {
          ...on CkeditorMarkup {
            html
            rawHtml
            markdown(header_style: "setext")
            plainText
          }
          ...on myNestedEntryType_Entry {
            # …
          }
        }
      }
    }
  }
}
```

### Related issues

- #216
- #329