### PR TITLE
catch any exception

### DIFF
--- a/src/data/FieldData.php
+++ b/src/data/FieldData.php
@@ -20,9 +20,9 @@ use craft\htmlfield\HtmlFieldData;
 use Embed\Embed;
 use Embed\Extractor;
 use Embed\Http\Crawler;
-use Exception;
 use Illuminate\Support\Collection;
 use IteratorAggregate;
+use Throwable;
 use Traversable;
 use Twig\Markup as TwigMarkup;
 
@@ -184,7 +184,7 @@ class FieldData extends HtmlFieldData implements IteratorAggregate, Countable
             $infos = $embed->getMulti(...$urls);
             $html = array_map(fn(Extractor $info) => $info->code->html, $infos);
             return str_replace(array_keys($urls), $html, $content);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             Craft::$app->getErrorHandler()->logException($e);
             return $content;
         }

--- a/src/data/FieldData.php
+++ b/src/data/FieldData.php
@@ -20,7 +20,7 @@ use craft\htmlfield\HtmlFieldData;
 use Embed\Embed;
 use Embed\Extractor;
 use Embed\Http\Crawler;
-use GuzzleHttp\Exception\GuzzleException;
+use Exception;
 use Illuminate\Support\Collection;
 use IteratorAggregate;
 use Traversable;
@@ -184,7 +184,7 @@ class FieldData extends HtmlFieldData implements IteratorAggregate, Countable
             $infos = $embed->getMulti(...$urls);
             $html = array_map(fn(Extractor $info) => $info->code->html, $infos);
             return str_replace(array_keys($urls), $html, $content);
-        } catch (GuzzleException $e) {
+        } catch (Exception $e) {
             Craft::$app->getErrorHandler()->logException($e);
             return $content;
         }


### PR DESCRIPTION
### Description
When trying to extract the embed html, catch any exception.

Example: try to embed a [facebook link](https://www.facebook.com/brilliantmaps/posts/pfbid0ir6opuHHerKctZ8Dw7BZDoPJq7CG7u24DG6ADYdeWs2mBuvLLJs4EPFYq1YT1mabl&show_text=true&width=500). 


### Related issues
n/a
