### PR TITLE
Bugfix/432 converting redactor fields nested in blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a bug where the CKEditor toolbar overflow menu could be cut off within Live Preview. ([#417](https://github.com/craftcms/ckeditor/issues/417))
 - Fixed a bug where the Field Limit setting was treating multibyte characters as multiple characters. ([#441](https://github.com/craftcms/ckeditor/issues/441))
+- Fixed a bug where the `ckeditor/convert` command wasn’t fully converting all Redactor fields within nested field contexts. ([#432](https://github.com/craftcms/ckeditor/issues/432)) 
 
 ## 3.13.0 - 2025-04-30
 

--- a/src/console/controllers/ConvertController.php
+++ b/src/console/controllers/ConvertController.php
@@ -270,22 +270,39 @@ class ConvertController extends Controller
             if (!isset($groupedFields[$prePath])) {
                 $groupedFields[$prePath] = [];
             }
-            $groupedFields[$prePath][$fieldUid] = $field;
+            $groupedFields[$prePath]['fields'][$fieldUid] = $field;
+            $groupedFields[$prePath]['originalPath'] = $path;
         }
 
-        // for each group, get the pc based on the preceding path, update it with the fields we have and that should be set in PC
-        foreach ($groupedFields as $path => $fields) {
-            $blockConfig = $this->projectConfig->get($path);
-            foreach ($fields as $fieldUid => $field) {
-                $blockConfig['fields'][$fieldUid] = $field;
-            }
+        // for each group
+        foreach ($groupedFields as $path => $values) {
+            // if there's only one nested field - save in the same way as a global field
+            if (count($values['fields']) == 1) {
+                $field = reset($values['fields']);
+                if ($field) {
+                    $this->projectConfig->set($values['originalPath'], $field);
+                    $this->stdout(PHP_EOL);
+                    $this->stdout(' → ', Console::FG_GREY);
+                    $this->stdout($this->markdownToAnsi(sprintf('Converting %s', $this->pathAndHandleMarkdown($values['originalPath'], $field))));
+                    $this->stdout(' …', Console::FG_GREY);
+                    $this->stdout(" ✓ Field converted", Console::FG_GREEN);
+                }
+            } else {
+                // get the pc based on the preceding path (block), update it with the fields we have and that block should be set in PC
+                $blockConfig = $this->projectConfig->get($path);
+                if ($blockConfig) {
+                    foreach ($values['fields'] as $fieldUid => $field) {
+                        $blockConfig['fields'][$fieldUid] = $field;
+                    }
 
-            $this->projectConfig->set($path, $blockConfig);
-            $this->stdout(PHP_EOL);
-            $this->stdout(' → ', Console::FG_GREY);
-            $this->stdout($this->markdownToAnsi(sprintf('Converting fields inside %s', $this->pathAndHandleMarkdown($path, $blockConfig))));
-            $this->stdout(' …', Console::FG_GREY);
-            $this->stdout(" ✓ Nested fields converted", Console::FG_GREEN);
+                    $this->projectConfig->set($path, $blockConfig);
+                    $this->stdout(PHP_EOL);
+                    $this->stdout(' → ', Console::FG_GREY);
+                    $this->stdout($this->markdownToAnsi(sprintf('Converting fields inside %s', $this->pathAndHandleMarkdown($path, $blockConfig))));
+                    $this->stdout(' …', Console::FG_GREY);
+                    $this->stdout(" ✓ Nested fields converted", Console::FG_GREEN);
+                }
+            }
         }
 
         $this->stdout("\n\n ✓ Finished converting Redactor fields.\n", Console::FG_GREEN, Console::BOLD);

--- a/src/console/controllers/ConvertController.php
+++ b/src/console/controllers/ConvertController.php
@@ -193,6 +193,7 @@ class ConvertController extends Controller
         $ckeConfigs = $this->ckeConfigs->getAll();
         $fieldSettingsByConfig = [];
         $configMap = [];
+        $convertedFields = [];
 
         foreach ($fields as $path => $field) {
             $this->stdout(' → ', Console::FG_GREY);
@@ -246,16 +247,48 @@ class ConvertController extends Controller
                     $field['settings']['uiMode'],
                 );
 
-                $this->projectConfig->set($path, $field);
+                // if the converted field's path is just fields.<uid> - set PC
+                if (str_starts_with($path, 'fields.')) {
+                    $this->projectConfig->set($path, $field);
+                    $this->stdout(" ✓ Field converted\n", Console::FG_GREEN);
+                } else {
+                    // otherwise we need to do more processing
+                    $convertedFields[$path] = $field;
+                    $this->stdout(" ~ Nested field will be converted later on\n", Console::FG_YELLOW);
+                }
             } catch (OperationAbortedException) {
                 $this->stdout(" ✕ Field skipped\n", Console::FG_YELLOW);
                 continue;
             }
-
-            $this->stdout(" ✓ Field converted\n", Console::FG_GREEN);
         }
 
-        $this->stdout("\n ✓ Finished converting Redactor fields.\n", Console::FG_GREEN, Console::BOLD);
+        $groupedFields = [];
+        // group converted fields by path that precedes fields.<uid>
+        foreach ($convertedFields as $path => $field) {
+            $prePath = rtrim(substr($path, 0, strrpos($path, '.')), '.fields.');
+            $fieldUid = substr($path, strrpos($path, '.') + 1);
+            if (!isset($groupedFields[$prePath])) {
+                $groupedFields[$prePath] = [];
+            }
+            $groupedFields[$prePath][$fieldUid] = $field;
+        }
+
+        // for each group, get the pc based on the preceding path, update it with the fields we have and that should be set in PC
+        foreach ($groupedFields as $path => $fields) {
+            $blockConfig = $this->projectConfig->get($path);
+            foreach ($fields as $fieldUid => $field) {
+                $blockConfig['fields'][$fieldUid] = $field;
+            }
+
+            $this->projectConfig->set($path, $blockConfig);
+            $this->stdout(PHP_EOL);
+            $this->stdout(' → ', Console::FG_GREY);
+            $this->stdout($this->markdownToAnsi(sprintf('Converting fields inside %s', $this->pathAndHandleMarkdown($path, $blockConfig))));
+            $this->stdout(' …', Console::FG_GREY);
+            $this->stdout(" ✓ Nested fields converted", Console::FG_GREEN);
+        }
+
+        $this->stdout("\n\n ✓ Finished converting Redactor fields.\n", Console::FG_GREEN, Console::BOLD);
         $this->stdout("\nCommit your project config changes, 
 and run `craft up` on other environments
 for the changes to take effect.\n", Console::FG_GREEN);


### PR DESCRIPTION
### Description
If you have two Redactor fields in the same block of a Matrix field, the PC will be updated as expected, but only the first Redactor field will be converted to CKE in the database.

All you need to do to reproduce is:
- clean cms v4 install with CKEditor and Redactor plugins, 
- create a Matrix field with one block with two Redactor fields in it (both can use the same config) 
- run the conversion command (`ckeditor/convert/redactor`)

The issue happens because when the first Redactor field inside the Matrix Block is converted, the Matrix field containing that field is also [marked as parsed](https://github.com/craftcms/cms/blob/4.15.6.2/src/models/ProjectConfigData.php#L62). So when the time comes to convert the other one, [this condition](https://github.com/craftcms/cms/blob/4.15.6.2/src/models/ProjectConfigData.php#L58) kicks in, causing the update event to not be triggered, and so the Matrix field doesn’t get updated again. 

Solution in this PR:
- Redactor fields in a global context get updated the same way they always have
- in all other cases, they’re stored for later processing
- once all fields have been processed, we look at the ones that were stored and group them by the owner
- if there’s only one Redactor field belonging to the owner, we set the project config in the same way we always have
- but if there are multiple Redactor fields belonging to the same owner, we get the project config for that owner; within that config, we update the Redactor fields we found and set the project config for that owner

### Related issues
#432 
