### PR TITLE
change how we get the string length for characterLimit validation (v3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where the CKEditor toolbar overflow menu could be cut off within Live Preview. ([#417](https://github.com/craftcms/ckeditor/issues/417))
+- Fixed a bug where the Field Limit setting was treating multibyte characters as multiple characters. ([#441](https://github.com/craftcms/ckeditor/issues/441))
 
 ## 3.13.0 - 2025-04-30
 

--- a/src/Field.php
+++ b/src/Field.php
@@ -234,7 +234,7 @@ class Field extends HtmlField
             $rules[] = [
                 function(ElementInterface $element) {
                     $value = strip_tags((string)$element->getFieldValue($this->handle));
-                    if (strlen($value) > $this->characterLimit) {
+                    if (mb_strlen($value) > $this->characterLimit) {
                         $element->addError(
                             "field:$this->handle",
                             Craft::t('ckeditor', '{field} should contain at most {max, number} {max, plural, one{character} other{characters}}.', [

--- a/src/Field.php
+++ b/src/Field.php
@@ -674,7 +674,11 @@ JS,
             return null;
         }
 
-        $value = preg_replace(StringHelper::invisibleCharsRegex(), '', $value);
+        $value = preg_replace(
+            '/\\x{00ad}|\\x{0083}|\\x{200b}|\\x{200c}|\\x{200d}|\\x{200e}|\\x{200f}|\\x{2062}|\\x{2063}|\\x{2064}|\\x{feff}/iu',
+            '',
+            $value
+        );
 
         // Redactor to CKEditor syntax for <figure>
         // (https://github.com/craftcms/ckeditor/issues/96)

--- a/src/Field.php
+++ b/src/Field.php
@@ -21,7 +21,6 @@ use craft\errors\InvalidHtmlTagException;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Html;
 use craft\helpers\Json;
-use craft\helpers\StringHelper;
 use craft\helpers\UrlHelper;
 use craft\htmlfield\events\ModifyPurifierConfigEvent;
 use craft\htmlfield\HtmlField;

--- a/src/Field.php
+++ b/src/Field.php
@@ -21,6 +21,7 @@ use craft\errors\InvalidHtmlTagException;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Html;
 use craft\helpers\Json;
+use craft\helpers\StringHelper;
 use craft\helpers\UrlHelper;
 use craft\htmlfield\events\ModifyPurifierConfigEvent;
 use craft\htmlfield\HtmlField;
@@ -672,6 +673,8 @@ JS,
         if (!$value) {
             return null;
         }
+
+        $value = preg_replace(StringHelper::invisibleCharsRegex(), '', $value);
 
         // Redactor to CKEditor syntax for <figure>
         // (https://github.com/craftcms/ckeditor/issues/96)


### PR DESCRIPTION
### Description
**First change:**
Use `mb_strlen` and not `strlen` when getting the string length for the character limit validation, so that multi-byte characters are counted as 1. 

This way, the results returned by the Word Count plugin match the count used for the `characterLimit` validation.
It also ensures that the characters like ą, ß, è are counted as one. 

**Second change:**
Remove invisible characters (like we do for asset filenames and search keywords) when serialising a field’s value.

[Separate PR](https://github.com/craftcms/ckeditor/pull/451) raised for v4.

### Related issues
#441
