### PR TITLE
change how we get the string length for characterLimit validation (v4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where the CKEditor toolbar overflow menu could be cut off within Live Preview. ([#417](https://github.com/craftcms/ckeditor/issues/417))
+- Fixed a bug where the Field Limit setting was treating multibyte characters as multiple characters. ([#441](https://github.com/craftcms/ckeditor/issues/441))
 - Fixed a bug where new paragraphs were getting inserted automatically after newly-added nested entries. ([#416](https://github.com/craftcms/ckeditor/issues/416))
 - Fixed a JavaScript error that occurred when saving a nested entry, for an owner element that didn’t use the new element editor (like global sets). ([#419](https://github.com/craftcms/ckeditor/issues/419))
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   },
   "require": {
     "php": "^8.2",
-    "craftcms/cms": "^5.6.0",
+    "craftcms/cms": "^5.6.1",
     "craftcms/html-field": "^3.4.0",
     "embed/embed": "^4.4",
     "nystudio107/craft-code-editor": ">=1.0.8 <=1.0.13 || ^1.0.16"

--- a/src/Field.php
+++ b/src/Field.php
@@ -548,7 +548,7 @@ class Field extends HtmlField implements ElementContainerFieldInterface, Mergeab
             $rules[] = [
                 function(ElementInterface $element) {
                     $value = strip_tags((string)$element->getFieldValue($this->handle));
-                    if (strlen($value) > $this->characterLimit) {
+                    if (mb_strlen($value) > $this->characterLimit) {
                         $element->addError(
                             "field:$this->handle",
                             Craft::t('ckeditor', '{field} should contain at most {max, number} {max, plural, one{character} other{characters}}.', [

--- a/src/Field.php
+++ b/src/Field.php
@@ -818,6 +818,8 @@ class Field extends HtmlField implements ElementContainerFieldInterface, Mergeab
             return null;
         }
 
+        $value = preg_replace(StringHelper::invisibleCharsRegex(), '', $value);
+
         // Redactor to CKEditor syntax for <figure>
         // (https://github.com/craftcms/ckeditor/issues/96)
         $value = $this->_normalizeFigures($value);


### PR DESCRIPTION
### Description
v4 version of https://github.com/craftcms/ckeditor/pull/443

(cms requirement bumped from `^5.6.0` to `^5.6.1` as that’s when the `StringHelper::invisibleCharsRegex()` method was added)


### Related issues
#441 
