### PR TITLE
register missing translations

### DIFF
--- a/src/translations/en/ckeditor.php
+++ b/src/translations/en/ckeditor.php
@@ -47,4 +47,6 @@ return [
     '{attribute} isn’t valid JSON.' => '{attribute} isn’t valid JSON.',
     '{field} should contain at most {max, number} {max, plural, one{character} other{characters}}.' => '{field} should contain at most {max, number} {max, plural, one{character} other{characters}}.',
     '{field} should contain at most {max, number} {max, plural, one{word} other{words}}.' => '{field} should contain at most {max, number} {max, plural, one{word} other{words}}.',
+    '{num, number} {num, plural, =1{character} other{characters}}' => '{num, number} {num, plural, =1{character} other{characters}}',
+    '{num, number} {num, plural, =1{word} other{words}}' => '{num, number} {num, plural, =1{word} other{words}}',
 ];

--- a/src/web/assets/ckeditor/CkeditorAsset.php
+++ b/src/web/assets/ckeditor/CkeditorAsset.php
@@ -66,6 +66,8 @@ class CkeditorAsset extends BaseCkeditorPackageAsset
                 'Insert link',
                 'Link to the current site',
                 'Site: {name}',
+                '{num, number} {num, plural, =1{character} other{characters}}',
+                '{num, number} {num, plural, =1{word} other{words}}',
             ]);
         }
     }


### PR DESCRIPTION
### Description
Register missing translations, so they can be changed via `translations/<lang>/ckeditor.php` files.


### Related issues
n/a
