### PR TITLE
make ckeditor config name translatable

### DIFF
--- a/src/CkeConfig.php
+++ b/src/CkeConfig.php
@@ -70,6 +70,11 @@ class CkeConfig extends Model
 
     public function __construct($config = [])
     {
+        // make the config name translatable
+        if (isset($config['name'])) {
+            $config['name'] = Craft::t('ckeditor', $config['name']);
+        }
+
         if (isset($config['toolbar']) && is_array($config['toolbar'])) {
             // anchor → bookmark
             $key = array_search('anchor', $config['toolbar']);

--- a/src/templates/cke-configs/_index.twig
+++ b/src/templates/cke-configs/_index.twig
@@ -17,7 +17,7 @@
 {% set tableData = ckeConfigs|map(config => {
   id: config.uid,
   name: config.name|e,
-  title: config.name|e,
+  title: config.name|e|t('ckeditor'),
   url: url("settings/ckeditor/#{config.uid}"),
 }) %}
 


### PR DESCRIPTION
### Description
Make CKEditor config name translatable (via `ckeditor` translation category).

Before (“Default” config):
<img width="449" height="342" alt="Screenshot 2025-08-18 at 09 45 38" src="https://github.com/user-attachments/assets/dbaf647f-f55f-43f4-85d3-8b9c9303f157" />
<img width="659" height="468" alt="Screenshot 2025-08-18 at 09 45 25" src="https://github.com/user-attachments/assets/7373a576-510a-4726-80ca-de500b3967fa" />

After (“Default” config):
<img width="451" height="371" alt="Screenshot 2025-08-18 at 09 44 49" src="https://github.com/user-attachments/assets/f0270ed8-26e9-4e44-93ef-92d3d58fcd6c" />
<img width="653" height="464" alt="Screenshot 2025-08-18 at 09 45 07" src="https://github.com/user-attachments/assets/34b33c09-cfcb-420f-9efb-60ed68c7c269" />


### Related issues
#457 
