### PR TITLE
remove unused method that crept back in during one of the merges

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -601,16 +601,6 @@ class Field extends HtmlField implements ElementContainerFieldInterface, Mergeab
     /**
      * @inheritdoc
      */
-    public function settingsAttributes(): array
-    {
-        $attributes = ArrayHelper::without(parent::settingsAttributes(), 'createButtonLabel');
-        $attributes[] = 'entryTypes';
-        return $attributes;
-    }
-
-    /**
-     * @inheritdoc
-     */
 
     public function getUriFormatForElement(NestedElementInterface $element): ?string
     {

--- a/src/translations/en/ckeditor.php
+++ b/src/translations/en/ckeditor.php
@@ -40,7 +40,6 @@ return [
     'Raw content only' => 'Raw content only',
     'Removes any potentially-malicious code on save, by running the submitted data through {link}.' => 'Removes any potentially-malicious code on save, by running the submitted data through {link}.',
     'Show as a separate button' => 'Show as a separate button',
-    'Show as a separate button' => 'Show as a separate button',
     'Show in a dropdown' => 'Show in a dropdown',
     'Show word count' => 'Show word count',
     'Site: {name}' => 'Site: {name}',

--- a/src/web/assets/ckeconfig/CkeConfigAsset.php
+++ b/src/web/assets/ckeconfig/CkeConfigAsset.php
@@ -60,5 +60,4 @@ class CkeConfigAsset extends AssetBundle
             ]);
         }
     }
-
 }


### PR DESCRIPTION
### Description
This PR removes `Field::settingsAttributes()` method, which is no longer used in v5 (removed as part of this PR: https://github.com/craftcms/ckeditor/pull/423). It crept back in during one of the merges.

It caused an error where you couldn't save a CKEditor field due to the `Getting unknown property: craft\ckeditor\Field::entryTypes` error.


### Related issues
n/a
