### PR TITLE
Bugfix/505 propagate value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed an error that could occur when creating a nested entry. ([#505](https://github.com/craftcms/ckeditor/issues/505))
 - Fixed a bug where `&nbps;` briefly appeared below the editor on page load, if the “Show word count” setting was enabled. ([#507](https://github.com/craftcms/ckeditor/issues/507))
 
 ## 4.11.1 - 2026-02-18

--- a/src/Field.php
+++ b/src/Field.php
@@ -1939,7 +1939,7 @@ JS,
         // causing the nested entry in the site we propagated to, to have a wrong ID
         // the CKE content references X, but X nested entry is marked as deleted and Y nested entry  was created in its place
         Event::on(Drafts::class, Drafts::EVENT_BEFORE_APPLY_DRAFT, function (DraftEvent $event) {
-            if ($event->draft->propagateAll && $event->canonical->id === $event->draft->id) {
+            if ($event->draft->propagateAll && $event->draft->getIsUnpublishedDraft()) {
                 $event->draft->propagateAll = false;
             }
         });

--- a/src/Field.php
+++ b/src/Field.php
@@ -11,6 +11,7 @@ use Craft;
 use craft\base\CrossSiteCopyableFieldInterface;
 use craft\base\ElementContainerFieldInterface;
 use craft\base\ElementInterface;
+use craft\base\Event;
 use craft\base\FieldInterface;
 use craft\base\MergeableFieldInterface;
 use craft\base\NestedElementInterface;
@@ -38,6 +39,7 @@ use craft\elements\User;
 use craft\enums\PropagationMethod;
 use craft\errors\InvalidHtmlTagException;
 use craft\events\CancelableEvent;
+use craft\events\DraftEvent;
 use craft\events\DuplicateNestedElementsEvent;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Cp;
@@ -56,6 +58,7 @@ use craft\models\EntryType;
 use craft\models\ImageTransform;
 use craft\models\Section;
 use craft\models\Volume;
+use craft\services\Drafts;
 use craft\services\ElementSources;
 use craft\web\View;
 use GraphQL\Type\Definition\Type;
@@ -1925,5 +1928,20 @@ JS,
             /** @phpstan-ignore-next-line */
             self::entryManager($this)->duplicateNestedElements($from, $to, force: true);
         }
+
+        // when the field is translatable (e.g. for each site);
+        // you create a new entry and add nested entry into a cke field while the entry is fresh
+        // during autosave, that nested entry gets duplicated into the other site correctly (along with value adjustment)
+        // however when you then fully save the owner,
+        // the duplication is triggered twice - during Drafts::applyDraft() and during Drafts::removeDraftData()
+        // the changes in 5.9.0 mean that the nested entries get duplicated and adjusted twice
+        // (via NEM::saveNestedElements > duplicateNestedElements() route)
+        // causing the nested entry in the site we propagated to, to have a wrong ID
+        // the CKE content references X, but X nested entry is marked as deleted and Y nested entry  was created in its place
+        Event::on(Drafts::class, Drafts::EVENT_BEFORE_APPLY_DRAFT, function (DraftEvent $event) {
+            if ($event->draft->propagateAll && $event->canonical->id === $event->draft->id) {
+                $event->draft->propagateAll = false;
+            }
+        });
     }
 }

--- a/src/Field.php
+++ b/src/Field.php
@@ -1933,7 +1933,7 @@ JS,
         // you create a new entry and add nested entry into a cke field while the entry is fresh
         // during autosave, that nested entry gets duplicated into the other site correctly (along with value adjustment)
         // however when you then fully save the owner,
-        // the duplication is triggered twice - during Drafts::applyDraft() and during Drafts::removeDraftData()
+        // the duplication is triggered twice - from ElementsController::actionApplyDraft() and from Drafts::removeDraftData()
         // the changes in 5.9.0 mean that the nested entries get duplicated and adjusted twice
         // (via NEM::saveNestedElements > duplicateNestedElements() route)
         // causing the nested entry in the site we propagated to, to have a wrong ID

--- a/src/Field.php
+++ b/src/Field.php
@@ -1938,7 +1938,7 @@ JS,
         // (via NEM::saveNestedElements > duplicateNestedElements() route)
         // causing the nested entry in the site we propagated to, to have a wrong ID
         // the CKE content references X, but X nested entry is marked as deleted and Y nested entry  was created in its place
-        Event::on(Drafts::class, Drafts::EVENT_BEFORE_APPLY_DRAFT, function (DraftEvent $event) {
+        Event::on(Drafts::class, Drafts::EVENT_BEFORE_APPLY_DRAFT, function(DraftEvent $event) {
             if ($event->draft->propagateAll && $event->draft->getIsUnpublishedDraft()) {
                 $event->draft->propagateAll = false;
             }

--- a/src/Field.php
+++ b/src/Field.php
@@ -1914,10 +1914,12 @@ JS,
      */
     public function propagateValue(ElementInterface $from, ElementInterface $to): void
     {
+        $wasValueEmpty = $this->isValueEmpty($to->getFieldValue($this->handle), $to);
+
         /** @phpstan-ignore-next-line */
         parent::propagateValue($from, $to);
 
-        if (!$from->propagateAll) {
+        if (!$from->propagateAll && $wasValueEmpty) {
             // NestedElementManager won't duplicate the nested entries automatically,
             // because the field has a value in the target site (the HTML content), so isValueEmpty() is false.
             /** @phpstan-ignore-next-line */


### PR DESCRIPTION
Recent changes related to `Element::$propagateRequired` are, in certain cases:

### Issue 1

causing infinite recursion when attempting to add a nested entry into a CKEditor field

**Tip:** having Xdebug enabled helps it error faster as it’ll error out with it detecting an infinite recursion; otherwise, you have to wait for the timeout (or it’ll crash your ddev).

**Steps to reproduce:**
1. clean 5.9.0+ (I used 5.9.14) installation with CKE 4.11.1
2. create 2 sites
3. create an entry type (`et1`) that contains the title field
4. create a CKE field (`cke`) with a config that allows nested entries; under “Entry Types” select `et1`; translation method: not translatable
5. create entry type `et2` that contains the title and the cke field
6. create a section (`sect1`) with all the default settings (propagate: all, enabled for both sites, etc); turn off revisions (for easier debugging); under entry type choose `et2`
7. create an entry in `sect1`, give it a title and fully save; 
8. edit the entry from the previous step, add a nested entry to the `cke` field; once the slideout closes, you should see the warning where the autosaving spinner is (next to the root element’s title)

**Root cause:**
The issue is linked to the changes from [this CKE PR](https://github.com/craftcms/ckeditor/pull/479) and [this CMS PR](https://github.com/craftcms/cms/pull/18003).

**Fix:**
We only want to ensure nested elements are duplicated if the field didn’t have a value in the first place (before we propagated it from the $from` element).

### Issue 2

causing an entry nested inside a CKE field to have a mismatched ID (and therefore preventing the user from opening and editing it)

**Steps to reproduce:**
- steps 1-6 from issue 1, but ensure that in step 4, the `cke` field has the translation method set to: for each site
- create a new entry in `sect1` and while it’s still fresh, add a nested entry to the `cke` field & fully save
- edit the root entry again and try to open the nested entry; it’ll open fine in the site you created the root entry for, but if you switch to the other site and try to open it, it’ll error (Invalid element ID)

**Root cause:**
When the field is translatable (e.g. for each site), and you create a new entry and add a nested entry into a cke field while the entry is fresh, autosave will kick in, and that nested entry gets duplicated into the other site correctly (along with value adjustment).
However, when you then fully save the owner, the duplication is triggered twice - from `ElementsController::actionApplyDraft()` and from `Drafts::removeDraftData()`.
The changes from 5.9.0 mean that the nested entries get duplicated and adjusted twice (via NEM::saveNestedElements > duplicateNestedElements() route), causing the nested entry in the site we propagated to, to have a wrong ID (the CKE content references X, but `X` nested entry is marked as deleted, and `Y` nested entry was created in its place). 

**Fix:**
As all the content changes should have been done during the draft application, ensure that `propagateAll` is set to false when removing draft data.

### Related issues
#505