### PR TITLE
ensure headingLevels is not an empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for CKEditor for Craft CMS
 
+## Unreleased
+
+- Fixed an error that occurred if a CKEditor field was saved with no selected heading levels. ([#511](https://github.com/craftcms/ckeditor/issues/511)) 
+
 ## 5.0.1 - 2026-03-03
 
 - Fixed a bug where new nested entries created for images weren’t always respecting the selected entry type. ([#510](https://github.com/craftcms/ckeditor/issues/510))

--- a/src/Field.php
+++ b/src/Field.php
@@ -628,6 +628,10 @@ class Field extends HtmlField implements ElementContainerFieldInterface, Mergeab
             $config['entryTypes'] = [];
         }
 
+        if (isset($config['headingLevels']) && $config['headingLevels'] === '') {
+            $config['headingLevels'] = [];
+        }
+
         if (isset($config['imageFieldPath'])) {
             [$config['imageEntryTypeUid'], $config['imageFieldUid']] = explode('.', $config['imageFieldPath'], 2);
             unset($config['imageFieldPath']);

--- a/src/helpers/CkeditorConfig.php
+++ b/src/helpers/CkeditorConfig.php
@@ -8,7 +8,6 @@
 namespace craft\ckeditor\helpers;
 
 use Craft;
-use craft\ckeditor\models\EntryType as CkeEntryType;
 use Illuminate\Support\Collection;
 
 /**


### PR DESCRIPTION
### Description
When no heading levels are selected, ensure the value is set to an empty array and not an empty string.


### Related issues

- #511
- #514
