### PR TITLE
don't lose info on whether createAction should be available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed an error that occurred if a CKEditor field was saved with no selected heading levels. ([#511](https://github.com/craftcms/ckeditor/issues/511)) 
+- Fixed a bug where inline entry type creation wasn’t working. ([#515](https://github.com/craftcms/ckeditor/pull/515))
 
 ## 5.0.1 - 2026-03-03
 

--- a/src/helpers/CkeditorConfig.php
+++ b/src/helpers/CkeditorConfig.php
@@ -8,7 +8,6 @@
 namespace craft\ckeditor\helpers;
 
 use Craft;
-use craft\ckeditor\models\EntryType as CkeEntryType;
 use Illuminate\Support\Collection;
 
 /**

--- a/src/templates/_entry-type-select.twig
+++ b/src/templates/_entry-type-select.twig
@@ -6,7 +6,7 @@
     showHandles: true,
     showIndicators: showIndicators ?? allowOverrides,
     inputValueFn: et => allowOverrides ? et.toArray(['id', 'name', 'handle', 'expanded']) : null,
-    createAction: createAction,
+    createAction,
     registerJs: false,
     jsSettings: {
         allowOverrides,

--- a/src/templates/_entry-type-select.twig
+++ b/src/templates/_entry-type-select.twig
@@ -1,11 +1,12 @@
 {% set allowOverrides = allowOverrides ?? false %}
+{% set createAction = (create ?? false) ? 'entry-types/edit' : null %}
 
 {% embed '_includes/forms/componentSelect.twig' with {
     options: options ?? craft.app.entries.getAllEntryTypes(),
     showHandles: true,
     showIndicators: showIndicators ?? allowOverrides,
     inputValueFn: et => allowOverrides ? et.toArray(['id', 'name', 'handle', 'expanded']) : null,
-    createAction: (create ?? false) ? 'entry-types/edit' : null,
+    createAction: createAction,
     registerJs: false,
     jsSettings: {
         allowOverrides,


### PR DESCRIPTION
### Description
Fixes an issue where the “Create” button under Entry Types in the field’s config wasn’t being activated.

This was happening because we were setting the `createAction` to the correct value [here](https://github.com/craftcms/ckeditor/blob/5.0.1/src/templates/_entry-type-select.twig#L8) but not [here](https://github.com/craftcms/ckeditor/blob/5.0.1/src/templates/_entry-type-select.twig#L52).


### Related issues
n/a
