### PR TITLE
Strip query string from import map URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed an error that occurred if a CKEditor field was saved with no selected heading levels. ([#511](https://github.com/craftcms/ckeditor/issues/511))
 - Fixed a bug where inline entry type creation wasn’t working. ([#515](https://github.com/craftcms/ckeditor/pull/515))
+- Fixed a bug where import map URLs could have query strings appended to them. ([#516](https://github.com/craftcms/ckeditor/pull/516))
 
 ## 5.0.1 - 2026-03-03
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -16,6 +16,7 @@ use craft\elements\NestedElementManager;
 use craft\events\AssetBundleEvent;
 use craft\events\ModelEvent;
 use craft\events\RegisterComponentTypesEvent;
+use craft\helpers\UrlHelper;
 use craft\services\Fields;
 use craft\web\View;
 use yii\base\Event;
@@ -55,10 +56,10 @@ class Plugin extends \craft\base\Plugin
             $assetManager = $view->getAssetManager();
 
             $ckBundle = $assetManager->getBundle(CkeditorAsset::class);
-            $view->registerJsImport('ckeditor5', $assetManager->getAssetUrl($ckBundle, 'lib/ckeditor5.js', false));
-            $view->registerJsImport('ckeditor5/', $assetManager->getAssetUrl($ckBundle, 'lib/', false));
-            $view->registerJsImport('ckeditor5/translations/', $assetManager->getAssetUrl($ckBundle, 'lib/translations/', false));
-            $view->registerJsImport('@craftcms/ckeditor', $assetManager->getAssetUrl($ckBundle, 'ckeditor5-craftcms.js', false));
+            $view->registerJsImport('ckeditor5', UrlHelper::stripQueryString($assetManager->getAssetUrl($ckBundle, 'lib/ckeditor5.js', false)));
+            $view->registerJsImport('ckeditor5/', UrlHelper::stripQueryString($assetManager->getAssetUrl($ckBundle, 'lib/', false)));
+            $view->registerJsImport('ckeditor5/translations/', UrlHelper::stripQueryString($assetManager->getAssetUrl($ckBundle, 'lib/translations/', false)));
+            $view->registerJsImport('@craftcms/ckeditor', UrlHelper::stripQueryString($assetManager->getAssetUrl($ckBundle, 'ckeditor5-craftcms.js', false)));
 
             $configBundle = $assetManager->getBundle(FieldSettingsAsset::class);
             $view->registerJsImport('@craftcms/ckeditor-config', $assetManager->getAssetUrl($configBundle, 'fieldsettings.js'));

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -56,10 +56,10 @@ class Plugin extends \craft\base\Plugin
             $assetManager = $view->getAssetManager();
 
             $ckBundle = $assetManager->getBundle(CkeditorAsset::class);
-            $view->registerJsImport('ckeditor5', UrlHelper::stripQueryString($assetManager->getAssetUrl($ckBundle, 'lib/ckeditor5.js', false)));
+            $view->registerJsImport('ckeditor5', $assetManager->getAssetUrl($ckBundle, 'lib/ckeditor5.js', false));
             $view->registerJsImport('ckeditor5/', UrlHelper::stripQueryString($assetManager->getAssetUrl($ckBundle, 'lib/', false)));
             $view->registerJsImport('ckeditor5/translations/', UrlHelper::stripQueryString($assetManager->getAssetUrl($ckBundle, 'lib/translations/', false)));
-            $view->registerJsImport('@craftcms/ckeditor', UrlHelper::stripQueryString($assetManager->getAssetUrl($ckBundle, 'ckeditor5-craftcms.js', false)));
+            $view->registerJsImport('@craftcms/ckeditor', $assetManager->getAssetUrl($ckBundle, 'ckeditor5-craftcms.js', false));
 
             $configBundle = $assetManager->getBundle(FieldSettingsAsset::class);
             $view->registerJsImport('@craftcms/ckeditor-config', $assetManager->getAssetUrl($configBundle, 'fieldsettings.js'));


### PR DESCRIPTION
Strips the query strings (targeting `buildId` in this case) from the import map URLs that point to directories. 

After fixing it, I had the robots explain why to make sure I wasn't overlooking something.

> When a key ends with /, the corresponding value must also end with /. If the value has a query string appended, it no longer ends with /, and the browser normalizes it — effectively treating it as null (blocked).

Fixes https://github.com/craftcms/ckeditor/issues/511