### PR TITLE
container is the one closest input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where custom `toolbar` config settings were getting ignored. ([#522](https://github.com/craftcms/ckeditor/issues/522))
+- Fixed a bug where files uploaded to Assets fields could also be added to nearby CKEditor fields. ([#523](https://github.com/craftcms/ckeditor/issues/523))
 
 ## 5.1.0 - 2026-03-05
 

--- a/src/web/assets/ckeditor/dist/ckeditor5-craftcms.js
+++ b/src/web/assets/ckeditor/dist/ckeditor5-craftcms.js
@@ -177,7 +177,7 @@ class Xu extends au {
    */
   _attachUploader() {
     const _ = this.editor, E = _.config.get("defaultUploadFolderId");
-    E && (this.$container = $(_.sourceElement).parents(".input"), this.progressBar = new Craft.ProgressBar(
+    E && (this.$container = $(_.sourceElement).closest(".input"), this.progressBar = new Craft.ProgressBar(
       $('<div class="progress-shade"></div>').appendTo(this.$container)
     ), this.$fileInput = $("<input/>", {
       type: "file",

--- a/src/web/assets/ckeditor/src/image/imageinsert/imageinsertui.js
+++ b/src/web/assets/ckeditor/src/image/imageinsert/imageinsertui.js
@@ -261,7 +261,7 @@ export default class CraftImageInsertUI extends ImageInsertUI {
       return;
     }
 
-    this.$container = $(editor.sourceElement).parents('.input');
+    this.$container = $(editor.sourceElement).closest('.input');
     this.progressBar = new Craft.ProgressBar(
       $('<div class="progress-shade"></div>').appendTo(this.$container),
     );


### PR DESCRIPTION
### Description
Fixes an issue where the CKEditor’s image uploader was attached to all the editors' ancestors that contained the `.input` class.


### Related issues
#523
