### PR TITLE
merge toolbar config, don't override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for CKEditor for Craft CMS
 
+## Unreleased
+
+- Fixed a bug where custom `toolbar` config settings were getting ignored. ([#522](https://github.com/craftcms/ckeditor/issues/522))
+
 ## 5.1.0 - 2026-03-05
 
 - Updated CKEditor 5 to 47.6.0. ([#518](https://github.com/craftcms/ckeditor/pull/518))

--- a/src/Field.php
+++ b/src/Field.php
@@ -1446,12 +1446,14 @@ import {create} from '@craftcms/ckeditor';
     language: $languageJs,
   }, $baseConfigJs, $configOptionsJs, {
     plugins: $configPlugins,
-    toolbar: {
-      items: $toolbarJs
-    },
     removePlugins: []
   });
 
+
+  if (!jQuery.isPlainObject(config.toolbar)) {
+    config.toolbar = {};
+  }
+  config.toolbar.items = $toolbarJs;
 
   // special case for heading config, because of the Heading Levels
   // see https://github.com/craftcms/ckeditor/issues/431


### PR DESCRIPTION
### Description
Ensure we merge toolbar config, not override it. 

Issue: if you have
```
{
  "toolbar": {
    "shouldNotGroupWhenFull": true
  }
}
```
in your field’s config options (or the JS version of it), it would get lost when instantiating the field.

This PR ensures we merge whatever’s in the Config Options with the toolbar items.

### Related issues
#522 
