### PR TITLE
cke compliant language codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 
+- Added `craft\ckeditor\web\assets\BaseCkeditorPackageAsset::getImportCompliantLanguage()`.
 - Fixed a bug where custom `toolbar` config settings were getting ignored. ([#522](https://github.com/craftcms/ckeditor/issues/522))
 - Fixed a bug where files uploaded to Assets fields could also be added to nearby CKEditor fields. ([#523](https://github.com/craftcms/ckeditor/issues/523))
 - Fixed an error that could occur when registering a custom CKEditor plugin. ([#525](https://github.com/craftcms/ckeditor/issues/525))
+- Fixed a JavaScript error that occurred if the control panel was being translated into a language that CKEditor doesn’t support. ([#526](https://github.com/craftcms/ckeditor/issues/526))
 
 ## 5.1.0 - 2026-03-05
 

--- a/src/Field.php
+++ b/src/Field.php
@@ -1432,7 +1432,8 @@ JS;
 
         // Add the translation import
         $uiLanguage = BaseCkeditorPackageAsset::uiLanguage();
-        $uiTranslationImport = "import coreTranslations from 'ckeditor5/translations/$uiLanguage.js';";
+        $importCompliantUiLanguage = BaseCkeditorPackageAsset::getImportCompliantLanguage(BaseCkeditorPackageAsset::uiLanguage());
+        $uiTranslationImport = "import coreTranslations from 'ckeditor5/translations/$importCompliantUiLanguage.js';";
 
         $view->registerScriptWithVars(fn($baseConfigJs, $toolbarJs, $languageJs, $showWordCountJs, $wordLimitJs, $characterLimitJs, $imageMode) => <<<JS
 $imports

--- a/src/web/assets/BaseCkeditorPackageAsset.php
+++ b/src/web/assets/BaseCkeditorPackageAsset.php
@@ -23,6 +23,113 @@ use craft\web\AssetBundle;
  */
 abstract class BaseCkeditorPackageAsset extends AssetBundle
 {
+    // a list of languages supported by CKEditor
+    private static array $ckeSupportedLanguages = [
+        'af',
+        'ar',
+        'ast',
+        'az',
+        'be',
+        'bg',
+        'bn',
+        'bs',
+        'ca',
+        'cs',
+        'da',
+        'de',
+        'de-ch',
+        'el',
+        'en',
+        'en-au',
+        'en-gb',
+        'eo',
+        'es',
+        'es-co',
+        'et',
+        'eu',
+        'fa',
+        'fi',
+        'fr',
+        'gl',
+        'gu',
+        'he',
+        'hi',
+        'hr',
+        'hu',
+        'hy',
+        'id',
+        'it',
+        'ja',
+        'jv',
+        'kk',
+        'km',
+        'kn',
+        'ko',
+        'ku',
+        'lt',
+        'lv',
+        'ms',
+        'nb',
+        'ne',
+        'nl',
+        'no',
+        'oc',
+        'pl',
+        'pt',
+        'pt-br',
+        'ro',
+        'ru',
+        'si',
+        'sk',
+        'sl',
+        'sq',
+        'sr',
+        'sr-latn',
+        'sv',
+        'th',
+        'ti',
+        'tk',
+        'tr',
+        'tt',
+        'ug',
+        'uk',
+        'ur',
+        'uz',
+        'vi',
+        'zh',
+        'zh-cn',
+    ];
+
+    /**
+     * Returns import compliant language code.
+     *
+     * CKEditor doesn't support all the languages that Craft does.
+     * It also often only support the major version, not localized ones (e.g. they support fr but not fr-FR, fr-CA, fr-BE etc).
+     * Since we're now using imports to get the correct translation files, we need to know if the file exists before we import it,
+     * or the field won't render.
+     *
+     * @param string $language
+     * @return string
+     */
+    public static function getImportCompliantLanguage(string $language): string
+    {
+        // first check if we have an exact match
+        if (in_array($language, self::$ckeSupportedLanguages, true)) {
+            return $language;
+        }
+
+        // if not - check if there's a major version that we can use
+        if (str_contains($language, '-')) {
+            $language = substr($language, 0, strpos($language, '-'));
+            if (in_array($language, self::$ckeSupportedLanguages, true)) {
+                return $language;
+            }
+        }
+
+        // if not, default to plain English
+        return 'en';
+    }
+
     /**
      * Returns the CKEditor UI language that should be used based on the app language.
      *

--- a/src/web/assets/BaseCkeditorPackageAsset.php
+++ b/src/web/assets/BaseCkeditorPackageAsset.php
@@ -110,6 +110,7 @@ abstract class BaseCkeditorPackageAsset extends AssetBundle
      *
      * @param string $language
      * @return string
+     * @since 5.2.0
      */
     public static function getImportCompliantLanguage(string $language): string
     {


### PR DESCRIPTION
### Description
CKEditor doesn’t support all the languages that Craft does. It also often only supports the major version, not localised ones (e.g., it supports `fr` but not `fr-FR`, `fr-CA`, `fr-BE`, etc.; doesn’t support Welsh or Icelandic, etc.).

Since we’re now using imports to get the correct translation files, we need to check whether the file exists before importing it, or the field won’t render.

In order to mitigate this issue, I created a list of translation files (language codes) that ship with CKEditor and a method that will “translate” Craft’s language code to CKEditor’s. We use this language code when creating the ui translation import statement.

@brianjhanson, if you have a better idea for handling this without maintaining a list of supported languages, please let me know!

Steps to reproduce:
1. clean 5.9.x installation with CKEditor 5.1.0
2. create a user that doesn’t have a language preference set via the control panel (in the "language" set to `null` in the `userpreferences` table)
3. create a CKEditor field (all the default settings are fine) 
4. create a section with an entry type that has the above field (all default settings)
5. create an entry in that section - the field will render as expected
6. in the config/general.php set the `defaultCpLanguage` to `nl-NL` or `de-DE` or `en-CA` or `is` or `cy`
7. refresh the entry from step 5 - the field won’t render, and you should see an error in the console

### Related issues
#526 
