### PR TITLE
migrate the cke config into a field for nested fields too (when going from cms 4 to 5)

### DIFF
--- a/src/migrations/m260220_182920_drop_cke_configs.php
+++ b/src/migrations/m260220_182920_drop_cke_configs.php
@@ -105,37 +105,15 @@ class m260220_182920_drop_cke_configs extends Migration
 
     private function getOldFieldSettings(string $fieldUid): ?array
     {
-        $query = (new Query())
-            ->select([
-                'fields.id',
-                'fields.dateCreated',
-                'fields.dateUpdated',
-                'fields.name',
-                'fields.handle',
-                'fields.context',
-                'fields.columnSuffix',
-                'fields.instructions',
-                'fields.searchable',
-                'fields.translationMethod',
-                'fields.translationKeyFormat',
-                'fields.type',
-                'fields.settings',
-                'fields.uid',
-            ])
-            ->from(['fields' => Table::FIELDS]);
+        $settings = (new Query())
+            ->select('settings')
+            ->from(['fields' => Table::FIELDS])
+            ->where(['uid' => $fieldUid])
+            ->scalar();
 
-        // todo: remove after the next breakpoint
-        if (Craft::$app->getDb()->columnExists(Table::FIELDS, 'dateDeleted')) {
-            $query->where(['fields.dateDeleted' => null]);
-        }
-
-        $query->andWhere(['fields.uid' => $fieldUid]);
-
-        $field = $query->one();
-
-        if ($field) {
+        if ($settings) {
             try {
-                return Json::decode($field['settings']);
+                return Json::decode($settings);
             } catch (Throwable $e) {
                 // fail silently
             }

--- a/src/migrations/m260220_182920_drop_cke_configs.php
+++ b/src/migrations/m260220_182920_drop_cke_configs.php
@@ -5,8 +5,12 @@ namespace craft\ckeditor\migrations;
 use Craft;
 use craft\ckeditor\Field;
 use craft\db\Migration;
+use craft\db\Query;
+use craft\db\Table;
 use craft\helpers\ArrayHelper;
+use craft\helpers\Json;
 use craft\helpers\ProjectConfig;
+use Throwable;
 
 /**
  * m260220_182920_drop_cke_configs migration.
@@ -29,6 +33,14 @@ class m260220_182920_drop_cke_configs extends Migration
             }
 
             $settings = ProjectConfig::unpackAssociativeArrays($fieldConfig['settings']);
+
+            // if we've already lost the ckeConfig and we have some new properties (e.g. toolbar)
+            // we need to get the "old" field's settings directly from the database (not from the memoized array)
+            if (!isset($settings['ckeConfig']) && isset($settings['toolbar'])) {
+                $fieldUid = str_replace('fields.', '', $fieldPath);
+                $settings = $this->getOldFieldSettings($fieldUid) ?? $settings;
+            }
+
             $ckeConfigUid = ArrayHelper::remove($settings, 'ckeConfig');
             $expandEntryButtons = ArrayHelper::remove($settings, 'expandEntryButtons') ?? false;
 
@@ -89,5 +101,46 @@ class m260220_182920_drop_cke_configs extends Migration
     {
         echo "m260220_182920_drop_cke_configs cannot be reverted.\n";
         return false;
+    }
+
+    private function getOldFieldSettings(string $fieldUid): ?array
+    {
+        $query = (new Query())
+            ->select([
+                'fields.id',
+                'fields.dateCreated',
+                'fields.dateUpdated',
+                'fields.name',
+                'fields.handle',
+                'fields.context',
+                'fields.columnSuffix',
+                'fields.instructions',
+                'fields.searchable',
+                'fields.translationMethod',
+                'fields.translationKeyFormat',
+                'fields.type',
+                'fields.settings',
+                'fields.uid',
+            ])
+            ->from(['fields' => Table::FIELDS]);
+
+        // todo: remove after the next breakpoint
+        if (Craft::$app->getDb()->columnExists(Table::FIELDS, 'dateDeleted')) {
+            $query->where(['fields.dateDeleted' => null]);
+        }
+
+        $query->andWhere(['fields.uid' => $fieldUid]);
+
+        $field = $query->one();
+
+        if ($field) {
+            try {
+                return Json::decode($field['settings']);
+            } catch (Throwable $e) {
+                // fail silently
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
### Description
If you’re upgrading from cms v4 to v5 at the same time as cke plugin v3 to v5, the cms migrations will cause the nested CKEditor fields to have their settings semi-updated before the `m260220_182920_drop_cke_configs` migration has a chance to do its thing. 

By the time `m260220_182920_drop_cke_configs` starts, some of the field’s settings, like `ckeConfig`, are lost from the working project config. In such a case, we need to get the field’s settings directly from the database (not from project config and not from the `Fields->_fields` memoized array) and work with that set of settings.


### Related issues

