### PR TITLE
Update README with clearer CKEditor plugin instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ The command will generate a new content migration, which will need to be run on 
 ## Adding CKEditor Plugins
 
 ### First Party plugins
-If you'd like to include any of the [first party packages](https://github.com/ckeditor/ckeditor5/tree/master/packages) from CKEditor, you can call `CkeditorConfig::registerFirstPartyPackage()` in the `init` function of a custom module.
+If you'd like to include any of the [first party packages](https://github.com/ckeditor/ckeditor5/tree/master/packages) from CKEditor not already included via `craft\ckeditor\helpers\CkeditorConfig::$pluginsByPackage`, you can call `CkeditorConfig::registerFirstPartyPackage()` in the `init` function of a custom module.
 
 ```php
 use craft\ckeditor\helpers\CkeditorConfig;

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ The command will generate a new content migration, which will need to be run on 
 ## Adding CKEditor Plugins
 
 ### First Party plugins
-If you'd like to include any of the [first party packages](https://github.com/ckeditor/ckeditor5/tree/master/packages) from CKEditor not already included via `craft\ckeditor\helpers\CkeditorConfig::$pluginsByPackage`, you can call `CkeditorConfig::registerFirstPartyPackage()` in the `init` function of a custom module.
+If you'd like to include any of the [first party packages](https://github.com/ckeditor/ckeditor5/tree/master/packages) from CKEditor not [already included](https://github.com/craftcms/ckeditor/blob/5.2.1/src/helpers/CkeditorConfig.php#L26), you can call `CkeditorConfig::registerFirstPartyPackage()` in the `init` function of a custom module.
 
 ```php
 use craft\ckeditor\helpers\CkeditorConfig;


### PR DESCRIPTION
Clarified instructions for including first party CKEditor packages.

I wanted to reference the lines or symbol directly for the link, but since the lines could change over time I couldn't figure out how to do that.

