### PR TITLE
don't strip out invisible chars from content, but don't count them to…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for CKEditor for Craft CMS
 
+## Unreleased
+
+- Fixed a bug where invisible characters were being stripped out of field contents. ([#537](https://github.com/craftcms/ckeditor/issues/537))
+
 ## 4.11.3 - 2026-03-05
 
 - Fixed an error that could occur if a CKEditor field’s value was instantiated without a known site ID. ([#500](https://github.com/craftcms/ckeditor/issues/500))

--- a/src/Field.php
+++ b/src/Field.php
@@ -561,6 +561,7 @@ class Field extends HtmlField implements ElementContainerFieldInterface, Mergeab
             $rules[] = [
                 function(ElementInterface $element) {
                     $value = strip_tags((string)$element->getFieldValue($this->handle));
+                    $value = preg_replace(StringHelper::invisibleCharsRegex(), '', $value);
                     if (mb_strlen($value) > $this->characterLimit) {
                         $element->addError(
                             "field:$this->handle",
@@ -830,8 +831,6 @@ class Field extends HtmlField implements ElementContainerFieldInterface, Mergeab
         if (!$value) {
             return null;
         }
-
-        $value = preg_replace(StringHelper::invisibleCharsRegex(), '', $value);
 
         // Redactor to CKEditor syntax for <figure>
         // (https://github.com/craftcms/ckeditor/issues/96)


### PR DESCRIPTION
### Description
In `4.11.0`, we began stripping out invisible characters. This was done as part of https://github.com/craftcms/ckeditor/pull/451, in response to https://github.com/craftcms/ckeditor/issues/441. 
In retrospect, this wasn’t the best idea, and we should leave the WYSIWYG content as. 

To help with the original issue that led to this change, I opted not to count that subset of invisible characters towards the character limit.


### Related issues
#537 + raised via support
