### PR TITLE
change the default link type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- New links now default to the first available link type option (usually “Entry”). ([#550](https://github.com/craftcms/ckeditor/pull/550))
 - Fixed a bug where invisible characters were being stripped out of field contents. ([#537](https://github.com/craftcms/ckeditor/issues/537))
 - Fixed a bug where Link modals had empty Site menus when no element was selected. ([#534](https://github.com/craftcms/ckeditor/discussions/534), [#545](https://github.com/craftcms/ckeditor/issues/545))
 

--- a/src/web/assets/ckeditor/dist/ckeditor5-craftcms.js
+++ b/src/web/assets/ckeditor/dist/ckeditor5-craftcms.js
@@ -1608,7 +1608,7 @@ class Vu extends Hn {
       const T = this._getLinkElementRefHandle();
       T ? this._showLinkTypeForm(
         this.linkTypeDropdownItemModels[T].linkOption
-      ) : this._showLinkTypeForm("default");
+      ) : this._urlInputValue().length == 0 ? (this._selectLinkTypeDropdownItem(this.linkOptions[0].refHandle), this._showLinkTypeForm(this.linkOptions[0])) : this._showLinkTypeForm("default");
     }), this.listenTo(O, "input", () => {
       this._toggleLinkTypeDropdownView();
     });

--- a/src/web/assets/ckeditor/src/link/linkui.js
+++ b/src/web/assets/ckeditor/src/link/linkui.js
@@ -228,7 +228,14 @@ export default class CraftLinkUI extends Plugin {
           this.linkTypeDropdownItemModels[elementRefHandle].linkOption,
         );
       } else {
-        this._showLinkTypeForm('default');
+        // if we don't have elementRefHandle and the input value is actually empty
+        // default to showing the first option from the linkOptions menu (e.g. Entry)
+        if (this._urlInputValue().length == 0) {
+          this._selectLinkTypeDropdownItem(this.linkOptions[0].refHandle);
+          this._showLinkTypeForm(this.linkOptions[0]);
+        } else {
+          this._showLinkTypeForm('default');
+        }
       }
     });
 


### PR DESCRIPTION
### Description
Changes the default link type to the first available link option. In most cases, that will turn out to be an Entry.


### Related issues
#533 
