### PR TITLE
download attribute shouldn't have a value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - New links now default to the first available link type option (usually “Entry”). ([#550](https://github.com/craftcms/ckeditor/pull/550))
 - Fixed a bug where invisible characters were being stripped out of field contents. ([#537](https://github.com/craftcms/ckeditor/issues/537))
 - Fixed a bug where Link modals had empty Site menus when no element was selected. ([#534](https://github.com/craftcms/ckeditor/discussions/534), [#545](https://github.com/craftcms/ckeditor/issues/545))
+- Fixed a bug where downloadable links’ `download` attributes were getting set to the value `"download"`. ([#551](https://github.com/craftcms/ckeditor/issues/551))
 
 ## 5.3.1 - 2026-03-20
 

--- a/src/helpers/CkeditorConfig.php
+++ b/src/helpers/CkeditorConfig.php
@@ -404,7 +404,7 @@ final class CkeditorConfig
                 'value' => 'download',
                 'conversion' => [
                     'type' => 'bool',
-                    'value' => 'download',
+                    'value' => true,
                     'model' => 'craftDownload',
                     'view' => 'download',
                 ],

--- a/src/web/assets/ckeditor/dist/ckeditor5-craftcms.js
+++ b/src/web/assets/ckeditor/dist/ckeditor5-craftcms.js
@@ -1229,7 +1229,9 @@ class ju extends Hn {
               const C = k.textNode || k.nodeBefore;
               i[d.model] ? f.setAttribute(
                 d.model,
-                i[d.model],
+                // for bool type options, if the value is set to true, set the attribute with empty value
+                // see https://github.com/craftcms/ckeditor/issues/551 for more info
+                d.type == "bool" && d.value == !0 ? "" : i[d.model],
                 f.createRangeOn(C)
               ) : f.removeAttribute(d.model, f.createRangeOn(C));
             } else {

--- a/src/web/assets/ckeditor/src/link/linkediting.js
+++ b/src/web/assets/ckeditor/src/link/linkediting.js
@@ -113,7 +113,11 @@ export default class CraftLinkEditing extends Plugin {
               if (extraAttributeValues[item.model]) {
                 writer.setAttribute(
                   item.model,
-                  extraAttributeValues[item.model],
+                  // for bool type options, if the value is set to true, set the attribute with empty value
+                  // see https://github.com/craftcms/ckeditor/issues/551 for more info
+                  item.type == 'bool' && item.value == true
+                    ? ''
+                    : extraAttributeValues[item.model],
                   writer.createRangeOn(node),
                 );
               } else {

--- a/src/web/assets/ckeditor/src/link/linkui.js
+++ b/src/web/assets/ckeditor/src/link/linkui.js
@@ -584,11 +584,11 @@ export default class CraftLinkUI extends Plugin {
             .bind('isOn')
             .to(linkCommand, attributeModel, (commandValue) => {
               if (commandValue === undefined) {
-                // set the initial toggle value to off after the page reload
+                // set the initial toggle value to "off" after the page reload
                 formView[attributeModel].element.value = '';
                 return false;
               } else {
-                // set the initial toggle value to on after the page reload
+                // set the initial toggle value to "on" after the page reload
                 formView[attributeModel].element.value =
                   advancedField.conversion.value;
                 return true;


### PR DESCRIPTION
### Description
When you toggle on the “Download” advanced link field option, the `download` attribute shouldn’t have a `download` value.


### Related issues
#551 
