### PR TITLE
Bugfix/558 inserting subsequent links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed an error that could occur when selecting an entry in the Link modal. ([#556](https://github.com/craftcms/ckeditor/issues/556))
+- Fixed a bug where the current text selection wasn’t respected when adding a new link. ([#558](https://github.com/craftcms/ckeditor/issues/558))
 
 ## 5.4.0 - 2026-03-30
 

--- a/src/web/assets/ckeditor/dist/ckeditor5-craftcms.js
+++ b/src/web/assets/ckeditor/dist/ckeditor5-craftcms.js
@@ -1313,7 +1313,7 @@ class Lu extends Tr {
     super.render();
     const _ = this.linkUi, E = _._linkUI, T = this.linkOption;
     this.element.addEventListener("click", function(O) {
-      (this.children[0].classList.contains("add") || O.target.classList.contains("ck-button__label")) && (E._hideUI(), _._showElementSelectorModal(T));
+      (this.children[0].classList.contains("add") || O.target.classList.contains("ck-button__label")) && (E._hideUI(!1), _._showElementSelectorModal(T));
     }), this.element.children.length == 0 && Craft.sendActionRequest(
       "POST",
       "ckeditor/ckeditor/render-element-with-supported-sites",
@@ -1764,7 +1764,7 @@ class Vu extends Hn {
                 }
             });
           setTimeout(() => {
-            this._linkUI._addToolbarView(), this._linkUI._balloon.showStack("main"), this._linkUI._addFormView(), this._linkUI._startUpdatingUI();
+            this._linkUI._showUI(!0);
           }, 100);
         } else
           f();

--- a/src/web/assets/ckeditor/src/link/linkelementview.js
+++ b/src/web/assets/ckeditor/src/link/linkelementview.js
@@ -66,7 +66,7 @@ export default class CraftLinkElementView extends View {
         this.children[0].classList.contains('add') ||
         ev.target.classList.contains('ck-button__label')
       ) {
-        _linkUI._hideUI();
+        _linkUI._hideUI(false);
         linkUi._showElementSelectorModal(linkOption);
       }
     });

--- a/src/web/assets/ckeditor/src/link/linkui.js
+++ b/src/web/assets/ckeditor/src/link/linkui.js
@@ -522,15 +522,9 @@ export default class CraftLinkUI extends Plugin {
           }
 
           setTimeout(() => {
-            // once element has been selected, show the form view so content authors can change the selected site
+            // once element has been selected, keep showing the balloon, so content authors can e.g. change the selected site
             // copied from https://github.com/ckeditor/ckeditor5/blob/v45.0.0/packages/ckeditor5-link/src/linkui.ts#L965-L976
-            this._linkUI._addToolbarView();
-
-            // Be sure panel with link is visible.
-            this._linkUI._balloon.showStack('main');
-
-            this._linkUI._addFormView();
-            this._linkUI._startUpdatingUI();
+            this._linkUI._showUI(true);
             // end copied
           }, 100);
         } else {


### PR DESCRIPTION
### Description
Fixes an issue where adding a link to a highlighted text wasn't respecting that selection if the user had already added a link anywhere else in the field.


### Related issues
#558 
