### PR TITLE
Fix removePlugins config option being overwritten

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -1619,7 +1619,10 @@ import {create} from '@craftcms/ckeditor';
     language: $languageJs,
   }, $baseConfigJs, customConfig, {
     plugins: $configPlugins,
-    removePlugins: []
+    removePlugins: [
+      ...($baseConfigJs?.removePlugins ?? []),
+      ...(customConfig?.removePlugins ?? []),
+    ]
   });
 
 


### PR DESCRIPTION
Fixes #578.

The custom `removePlugins` values from the field config were being overwritten by an empty array in the `Object.assign()` call inside the editor initialization JS, so configuring `removePlugins: ['PasteFromOffice']` (etc.) had no effect.

Now baseConfig and customConfig `removePlugins` arrays are merged into the final value before `extraRemovePlugins` (e.g. `WordCount`) gets pushed onto it.