### PR TITLE
Adds missing Norwegian translations for the new deletion blocker

### DIFF
--- a/src/translations/nb/ckeditor.php
+++ b/src/translations/nb/ckeditor.php
@@ -1,16 +1,20 @@
 <?php
 
 return [
+    '{numReferences, plural, =1{Reference} other{References}} queued to be replaced.' => '{numReferences, plural, =1{Referanse} other{Referanser}} satt i kø for å erstattes.',
     'Advanced' => 'Avansert',
     'Available Transforms' => 'Tilgjengelige bildeomforminger',
     'Changing this may result in data loss.' => 'Å endre denne kan føre til tap av data',
     'Column Type' => 'Kolonnetype',
     'Disable this at your own risk!' => 'Deaktiver på eget ansvar!',
-    'HTML Purifier Config' => 'Instillinger for HTML-rens',
+    'HTML Purifier Config' => 'Innstillinger for HTML-rens',
+    'Ignore {numReferences, plural, =1{reference} other{references}}' => 'Ignorer {numReferences, plural, =1{referanse} other{referanser}}',
     'Link to a category' => 'Link til en kategori',
     'Link to an entry' => 'Link til en artikkel',
     'Purify HTML' => 'Rens HTML-koden',
+    'Replace {numReferences, plural, =1{reference} other{references}}' => 'Erstatt {numReferences, plural, =1{referanse} other{referanser}}',
     'The type of column this field should get in the database.' => 'Kolonnetypen dette feltet skal ha i databasen.',
-    'View available settings' => 'Vis tilgjengelig instillinger',
-    'You can save custom {name} configs as {ext} files in {path}.' => 'Du kan lagre egendefinerte {name} instillinger som {ext} filer i {path}.',
+    'The {numTargets, plural, =1{{targetTypeSingular} is} other{{targetTypePlural} are}} referenced by CKEditor fields in {numReferences, number} other {numReferences, plural, =1{element} other{elements}}.' => '{numTargets, plural, =1{{targetTypeSingular} er} other{{targetTypePlural} er}} referert av CKEditor-felter i {numReferences, number} {numReferences, plural, =1{annet element} other{andre elementer}}.',
+    'View available settings' => 'Vis tilgjengelige innstillinger',
+    'You can save custom {name} configs as {ext} files in {path}.' => 'Du kan lagre egendefinerte {name} innstillinger som {ext} filer i {path}.',
 ];


### PR DESCRIPTION
Adds missing Norwegian static translations for the new deletion blocker.

Also fixes a couple of grammatical errors in existing Norwegian translations.

### Description



### Related issues

